### PR TITLE
Bug fixes

### DIFF
--- a/src/lib/trayManager/trayManager.go
+++ b/src/lib/trayManager/trayManager.go
@@ -10,8 +10,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type TrayManager struct {
@@ -153,7 +154,7 @@ func (tm *TrayManager) HandleStale(ctx context.Context) {
 
 				time.Sleep(interval / 2)
 
-				stale, err := tm.trayRepository.GetStale(interval)
+				stale, err := tm.trayRepository.GetStale(interval, interval*2)
 				if err != nil {
 					return
 				}

--- a/src/lib/trays/providers/gceProvider.go
+++ b/src/lib/trays/providers/gceProvider.go
@@ -3,11 +3,12 @@ package providers
 import (
 	"cattery/lib/config"
 	"cattery/lib/trays"
-	compute "cloud.google.com/go/compute/apiv1"
-	"cloud.google.com/go/compute/apiv1/computepb"
 	"context"
 	"errors"
 	"fmt"
+
+	compute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -113,7 +114,8 @@ func (g *GceProvider) CleanTray(tray *trays.Tray) error {
 			if e.Code != 404 {
 				return err
 			} else {
-				g.logger.Tracef("Tray deletion error, tray %s not found: %v", tray.GetId(), err)
+				g.logger.Tracef("Tray deletion error, tray %s not found, skipping: %v", tray.GetId(), err)
+				return nil
 			}
 		}
 		return err

--- a/src/lib/trays/repositories/iTrayRepository.go
+++ b/src/lib/trays/repositories/iTrayRepository.go
@@ -12,5 +12,5 @@ type ITrayRepository interface {
 	UpdateStatus(trayId string, status trays.TrayStatus, jobRunId int64, ghRunnerId int64) (*trays.Tray, error)
 	CountByTrayType(trayType string) (map[trays.TrayStatus]int, int, error)
 	MarkRedundant(trayType string, limit int) ([]*trays.Tray, error)
-	GetStale(d time.Duration) ([]*trays.Tray, error)
+	GetStale(d time.Duration, rd time.Duration) ([]*trays.Tray, error)
 }

--- a/src/lib/trays/repositories/mongodbTrayRepository.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository.go
@@ -4,10 +4,11 @@ import (
 	"cattery/lib/trays"
 	"context"
 	"errors"
+	"time"
+
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
-	"time"
 )
 
 type MongodbTrayRepository struct {
@@ -34,11 +35,18 @@ func (m *MongodbTrayRepository) GetById(trayId string) (*trays.Tray, error) {
 	return &result, nil
 }
 
-func (m *MongodbTrayRepository) GetStale(d time.Duration) ([]*trays.Tray, error) {
+func (m *MongodbTrayRepository) GetStale(d time.Duration, rd time.Duration) ([]*trays.Tray, error) {
 	dbResult, err := m.collection.Find(context.Background(),
-		bson.M{
-			"status":        bson.M{"$ne": trays.TrayStatusRunning},
-			"statusChanged": bson.M{"$lte": time.Now().UTC().Add(-d)},
+		bson.M{"$or": []bson.M{
+			{
+				"status":        bson.M{"$ne": trays.TrayStatusRunning},
+				"statusChanged": bson.M{"$lte": time.Now().UTC().Add(-d)},
+			},
+			{
+				"status":        trays.TrayStatusRunning,
+				"statusChanged": bson.M{"$lte": time.Now().UTC().Add(-rd)},
+			},
+		},
 		})
 	if err != nil {
 		return nil, err

--- a/src/lib/trays/repositories/mongodbTrayRepository_test.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository_test.go
@@ -482,7 +482,7 @@ func TestGetStale(t *testing.T) {
 	insertTestTrays(t, collection, []*TestTray{staleTray1, staleTray2, freshTray1, freshTray2})
 
 	// Test GetStale with 5 minute duration
-	staleTrays, err := repo.GetStale(5 * time.Minute)
+	staleTrays, err := repo.GetStale(5*time.Minute, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("GetStale failed: %v", err)
 	}
@@ -527,7 +527,7 @@ func TestGetStale(t *testing.T) {
 	insertTestTrays(t, collection, []*TestTray{freshTray1, freshTray2})
 
 	// Test GetStale again with 5 minute duration
-	staleTrays, err = repo.GetStale(5 * time.Minute)
+	staleTrays, err = repo.GetStale(5*time.Minute, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("GetStale failed: %v", err)
 	}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -7,19 +7,20 @@ import (
 	"cattery/lib/trays/repositories"
 	"cattery/server/handlers"
 	"context"
-	log "github.com/sirupsen/logrus"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 func Start() {
 
-	var logger = log.Logger{}
+	var logger = log.New()
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT)


### PR DESCRIPTION
cc https://github.com/paritytech/devops/issues/3875#issuecomment-3174150001

fixed: 
- Bug: stale trays finder sometimes doesn't see the stale trays, to reproduce: run workflow with matrix, wait when the machines are created and cancel the workflow, if they had time to register then they won't be removed

  **added handling for stale `running` trays**

- Minor bug: on VM preemption when google removed the machine cattery still tries to remove it

  **Not a bug but feature, cattery will still try to remove the vm just in case. The actual bug was in the 404 error handling, fixed**

- Minor bug: without db connection db silently dies with exit 1

  **fixed `server.go` logger**