### PR TITLE
Per-status thresholds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
 
   tests:
-    runs-on: parity-ubuntu
+    runs-on: ubuntu-latest
     env:
       DOCKER_API_VERSION: '1.44'
     steps:
@@ -55,7 +55,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
-    runs-on: parity-ubuntu
+    runs-on: ubuntu-latest
     env:
       VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.sha }}
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   docker-build:
     needs: [tests]
-    runs-on: parity-ubuntu
+    runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'main' || null }}
     env:
       REGISTRY_PATH: docker.io/${{ github.event_name == 'workflow_dispatch' && 'paritytech' || 'paritypr' }}/cattery

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: run tests
         working-directory: src
+        env:
+          CGO_ENABLED: 1   # required for -race
         run: |
           go test -tags=integration -race -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
           # go 1.25 covdata bug causes exit code 1 for packages without tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: run tests
         working-directory: src
         run: |
-          go test -tags=integration -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
+          go test -tags=integration -race -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
           # go 1.25 covdata bug causes exit code 1 for packages without tests
           # fail only if actual test failures exist
           if grep -q "^FAIL" test-output.txt; then

--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -6,6 +6,17 @@ database:
   uri: mongodb://localhost:27017/cattery
   database: cattery
 
+# Optional. Stale-tray cleanup loop. Defaults shown below.
+# A tray sitting in `status` for longer than its threshold is deleted.
+# `running` is intentionally absent — running trays are never stale.
+stale:
+  pollInterval: 1m
+  thresholds:
+    creating: 5m
+    registering: 5m
+    registered: 15m
+    deleting: 15m
+
 github:
   - name: paritytech-stg
     appId: 123456

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-playground/validator"
 	"github.com/go-viper/mapstructure/v2"
@@ -40,6 +41,7 @@ func SetForTest(t *testing.T, cfg *CatteryConfig) {
 type CatteryConfig struct {
 	Server    ServerConfig          `yaml:"server" validate:"required"`
 	Database  DatabaseConfig        `yaml:"database" validate:"required"`
+	Stale     StaleConfig           `yaml:"stale"`
 	Github    []*GitHubOrganization `yaml:"github" validate:"required,dive,required"`
 	Providers []*ProviderConfig     `yaml:"providers" validate:"required,dive,required"`
 	TrayTypes []*TrayType           `yaml:"trayTypes" validate:"required,dive,required"`
@@ -187,6 +189,46 @@ type ServerConfig struct {
 type DatabaseConfig struct {
 	Uri      string `yaml:"uri" validate:"required"`
 	Database string `yaml:"database" validate:"required"`
+}
+
+// StaleConfig configures the stale-tray cleanup loop.
+//
+// PollInterval is how often the loop checks for stale trays.
+// Thresholds maps a tray status name (lowercase: "creating", "registering",
+// "registered", "deleting") to the duration after which a tray sitting in
+// that status is considered stale. Statuses not present in the map are not
+// checked. "running" should not be set — running trays are never stale.
+//
+// Defaults are applied in StaleConfig.WithDefaults when fields are zero.
+type StaleConfig struct {
+	PollInterval time.Duration            `yaml:"pollInterval"`
+	Thresholds   map[string]time.Duration `yaml:"thresholds"`
+}
+
+// DefaultStalePollInterval is used when StaleConfig.PollInterval is zero.
+const DefaultStalePollInterval = time.Minute
+
+// DefaultStaleThresholds is used when StaleConfig.Thresholds is empty.
+// Creating/Registering are tight: a VM that hasn't booted+registered within
+// a few minutes is almost certainly broken. Registered is generous: a tray
+// may legitimately idle waiting for a job.
+var DefaultStaleThresholds = map[string]time.Duration{
+	"creating":    5 * time.Minute,
+	"registering": 5 * time.Minute,
+	"registered":  15 * time.Minute,
+	"deleting":    15 * time.Minute,
+}
+
+// WithDefaults returns a copy with zero/empty fields populated from defaults.
+func (s StaleConfig) WithDefaults() StaleConfig {
+	out := s
+	if out.PollInterval <= 0 {
+		out.PollInterval = DefaultStalePollInterval
+	}
+	if len(out.Thresholds) == 0 {
+		out.Thresholds = DefaultStaleThresholds
+	}
+	return out
 }
 
 type GitHubOrganization struct {

--- a/src/lib/config/config_test.go
+++ b/src/lib/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -439,6 +440,104 @@ trayTypes:
 
 	assert.NoError(t, err)
 	assert.Equal(t, "my-secret-token", config.Server.AgentSecret)
+}
+
+func TestLoadConfig_Stale(t *testing.T) {
+	t.Run("parses durations and threshold map from YAML", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "config_stale*.yaml")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		staleConfig := `
+server:
+  listenAddress: ":8080"
+  advertiseUrl: "http://localhost:8080"
+database:
+  uri: "mongodb://localhost:27017"
+  database: "cattery"
+stale:
+  pollInterval: 30s
+  thresholds:
+    creating: 2m
+    registered: 20m
+github:
+  - name: "test-org"
+    appId: 12345
+    appClientId: "Iv1.test123"
+    installationId: 67890
+    privateKeyPath: "path/to/key.pem"
+providers:
+  - name: "docker-provider"
+    type: "docker"
+trayTypes:
+  - name: "docker-local"
+    provider: "docker-provider"
+    runnerGroupId: 1
+    githubOrg: "test-org"
+`
+		_, err = tempFile.Write([]byte(staleConfig))
+		assert.NoError(t, err)
+		tempFile.Close()
+
+		configPath := tempFile.Name()
+		cfg, err := LoadConfig(&configPath)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.Stale.PollInterval)
+		assert.Equal(t, 2*time.Minute, cfg.Stale.Thresholds["creating"])
+		assert.Equal(t, 20*time.Minute, cfg.Stale.Thresholds["registered"])
+		// Status not present in YAML should be absent (defaults are applied later by WithDefaults).
+		_, hasRegistering := cfg.Stale.Thresholds["registering"]
+		assert.False(t, hasRegistering)
+	})
+
+	t.Run("missing stale block leaves zero value", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "config_nostale*.yaml")
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		bareConfig := `
+server:
+  listenAddress: ":8080"
+  advertiseUrl: "http://localhost:8080"
+database:
+  uri: "mongodb://localhost:27017"
+  database: "cattery"
+github:
+  - name: "test-org"
+    appId: 12345
+    appClientId: "Iv1.test123"
+    installationId: 67890
+    privateKeyPath: "path/to/key.pem"
+providers:
+  - name: "docker-provider"
+    type: "docker"
+trayTypes:
+  - name: "docker-local"
+    provider: "docker-provider"
+    runnerGroupId: 1
+    githubOrg: "test-org"
+`
+		_, err = tempFile.Write([]byte(bareConfig))
+		assert.NoError(t, err)
+		tempFile.Close()
+
+		configPath := tempFile.Name()
+		cfg, err := LoadConfig(&configPath)
+
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), cfg.Stale.PollInterval)
+		assert.Empty(t, cfg.Stale.Thresholds)
+
+		// WithDefaults must produce a fully populated config.
+		def := cfg.Stale.WithDefaults()
+		assert.Equal(t, DefaultStalePollInterval, def.PollInterval)
+		assert.Equal(t, DefaultStaleThresholds, def.Thresholds)
+	})
 }
 
 func TestProviderConfigGet(t *testing.T) {

--- a/src/lib/testutil/mock_tray_repository.go
+++ b/src/lib/testutil/mock_tray_repository.go
@@ -112,7 +112,7 @@ func (m *MockTrayRepository) List(_ context.Context) ([]*trays.Tray, error) {
 	return result, nil
 }
 
-func (m *MockTrayRepository) GetStale(_ context.Context, _ time.Duration) ([]*trays.Tray, error) {
+func (m *MockTrayRepository) GetStale(_ context.Context, _ map[trays.TrayStatus]time.Duration) ([]*trays.Tray, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.StaleErr != nil {

--- a/src/lib/testutil/mock_tray_repository.go
+++ b/src/lib/testutil/mock_tray_repository.go
@@ -120,3 +120,16 @@ func (m *MockTrayRepository) GetStale(_ context.Context, _ map[trays.TrayStatus]
 	}
 	return m.StaleTrays, nil
 }
+
+// SetStale atomically updates the stale-list and error returned by GetStale,
+// and inserts the supplied trays into the Trays map so DeleteTray can find them.
+// Safe to call concurrently with GetStale.
+func (m *MockTrayRepository) SetStale(staleTrays []*trays.Tray, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.StaleTrays = staleTrays
+	m.StaleErr = err
+	for _, tr := range staleTrays {
+		m.Trays[tr.Id] = tr
+	}
+}

--- a/src/lib/trayManager/trayManager.go
+++ b/src/lib/trayManager/trayManager.go
@@ -184,17 +184,21 @@ func (tm *TrayManager) DeleteTray(ctx context.Context, trayId string) (*trays.Tr
 }
 
 func (tm *TrayManager) HandleStale(ctx context.Context) {
-	interval := time.Minute * 15
+	cfg := config.Get().Stale.WithDefaults()
+	thresholds := resolveStaleThresholds(cfg.Thresholds)
+
+	log.Infof("Stale handler starting: pollInterval=%s thresholds=%v", cfg.PollInterval, formatThresholds(thresholds))
 
 	go func() {
+		ticker := time.NewTicker(cfg.PollInterval)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
-				time.Sleep(interval / 2)
-
-				stale, err := tm.trayRepository.GetStale(ctx, interval)
+			case <-ticker.C:
+				stale, err := tm.trayRepository.GetStale(ctx, thresholds)
 				if err != nil {
 					log.Errorf("Failed to get stale trays: %v", err)
 					continue
@@ -205,7 +209,7 @@ func (tm *TrayManager) HandleStale(ctx context.Context) {
 				}
 
 				for _, tray := range stale {
-					log.Debugf("Deleting stale tray: %s", tray.Id)
+					log.Debugf("Deleting stale tray: %s (status=%s)", tray.Id, tray.Status)
 					if _, err := tm.DeleteTray(ctx, tray.Id); err != nil {
 						log.Errorf("Failed to delete tray %s: %v", tray.Id, err)
 					}
@@ -214,6 +218,38 @@ func (tm *TrayManager) HandleStale(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// resolveStaleThresholds converts the string-keyed config map into a
+// TrayStatus-keyed map. Unknown or invalid status names are logged and
+// skipped; "running" is rejected since running trays are never stale.
+func resolveStaleThresholds(in map[string]time.Duration) map[trays.TrayStatus]time.Duration {
+	out := make(map[trays.TrayStatus]time.Duration, len(in))
+	for name, d := range in {
+		status, err := trays.TrayStatusFromString(name)
+		if err != nil {
+			log.Warnf("Ignoring stale threshold for unknown status %q", name)
+			continue
+		}
+		if status == trays.TrayStatusRunning {
+			log.Warnf("Ignoring stale threshold for status %q: running trays are never stale", name)
+			continue
+		}
+		if d <= 0 {
+			log.Warnf("Ignoring non-positive stale threshold for status %q: %s", name, d)
+			continue
+		}
+		out[status] = d
+	}
+	return out
+}
+
+func formatThresholds(m map[trays.TrayStatus]time.Duration) map[string]time.Duration {
+	out := make(map[string]time.Duration, len(m))
+	for s, d := range m {
+		out[s.String()] = d
+	}
+	return out
 }
 
 // ScaleForDemand scales trays for a given tray type based on the desired runner count.

--- a/src/lib/trayManager/trayManager_test.go
+++ b/src/lib/trayManager/trayManager_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -352,4 +353,223 @@ func TestCountTrays(t *testing.T) {
 	count, err := tm.CountTrays(context.Background(), "test-type")
 	assert.NoError(t, err)
 	assert.Equal(t, 7, count)
+}
+
+func TestResolveStaleThresholds(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]time.Duration
+		want map[trays.TrayStatus]time.Duration
+	}{
+		{
+			name: "valid statuses pass through",
+			in: map[string]time.Duration{
+				"creating":    5 * time.Minute,
+				"registering": 5 * time.Minute,
+				"registered":  15 * time.Minute,
+				"deleting":    10 * time.Minute,
+			},
+			want: map[trays.TrayStatus]time.Duration{
+				trays.TrayStatusCreating:    5 * time.Minute,
+				trays.TrayStatusRegistering: 5 * time.Minute,
+				trays.TrayStatusRegistered:  15 * time.Minute,
+				trays.TrayStatusDeleting:    10 * time.Minute,
+			},
+		},
+		{
+			name: "case-insensitive status names",
+			in: map[string]time.Duration{
+				"Creating":   1 * time.Minute,
+				"REGISTERED": 2 * time.Minute,
+			},
+			want: map[trays.TrayStatus]time.Duration{
+				trays.TrayStatusCreating:   1 * time.Minute,
+				trays.TrayStatusRegistered: 2 * time.Minute,
+			},
+		},
+		{
+			name: "unknown status is skipped",
+			in: map[string]time.Duration{
+				"creating": 5 * time.Minute,
+				"bogus":    1 * time.Minute,
+			},
+			want: map[trays.TrayStatus]time.Duration{
+				trays.TrayStatusCreating: 5 * time.Minute,
+			},
+		},
+		{
+			name: "running is rejected (running trays are never stale)",
+			in: map[string]time.Duration{
+				"creating": 5 * time.Minute,
+				"running":  1 * time.Minute,
+			},
+			want: map[trays.TrayStatus]time.Duration{
+				trays.TrayStatusCreating: 5 * time.Minute,
+			},
+		},
+		{
+			name: "non-positive duration is rejected",
+			in: map[string]time.Duration{
+				"creating":    5 * time.Minute,
+				"registering": 0,
+				"registered":  -1 * time.Minute,
+			},
+			want: map[trays.TrayStatus]time.Duration{
+				trays.TrayStatusCreating: 5 * time.Minute,
+			},
+		},
+		{
+			name: "empty input yields empty output",
+			in:   map[string]time.Duration{},
+			want: map[trays.TrayStatus]time.Duration{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveStaleThresholds(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHandleStale_DeletesStaleTrays(t *testing.T) {
+	// Override config so the loop polls fast.
+	config.SetForTest(t, &config.CatteryConfig{
+		Server: config.ServerConfig{
+			ListenAddress: ":8080",
+			AdvertiseUrl:  "http://localhost",
+		},
+		Database: config.DatabaseConfig{Uri: "x", Database: "y"},
+		Stale: config.StaleConfig{
+			PollInterval: 10 * time.Millisecond,
+			Thresholds:   map[string]time.Duration{"creating": time.Second},
+		},
+	})
+
+	repo := testutil.NewMockTrayRepository()
+	repo.SetStale([]*trays.Tray{
+		{Id: "stale-1", TrayTypeName: "t1", ProviderName: "docker", Status: trays.TrayStatusCreating},
+		{Id: "stale-2", TrayTypeName: "t1", ProviderName: "docker", Status: trays.TrayStatusCreating},
+	}, nil)
+
+	prov := &mockProvider{name: "docker"}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tm.HandleStale(ctx)
+
+	// Expect both stale trays to be cleaned within a few poll cycles.
+	assert.Eventually(t, func() bool {
+		prov.mu.Lock()
+		defer prov.mu.Unlock()
+		seen := map[string]bool{}
+		for _, id := range prov.cleaned {
+			seen[id] = true
+		}
+		return seen["stale-1"] && seen["stale-2"]
+	}, 500*time.Millisecond, 10*time.Millisecond, "expected both stale trays to be cleaned")
+}
+
+func TestHandleStale_GetStaleErrorDoesNotCrashLoop(t *testing.T) {
+	config.SetForTest(t, &config.CatteryConfig{
+		Server:   config.ServerConfig{ListenAddress: ":8080", AdvertiseUrl: "http://localhost"},
+		Database: config.DatabaseConfig{Uri: "x", Database: "y"},
+		Stale: config.StaleConfig{
+			PollInterval: 10 * time.Millisecond,
+			Thresholds:   map[string]time.Duration{"creating": time.Second},
+		},
+	})
+
+	repo := testutil.NewMockTrayRepository()
+	repo.SetStale(nil, errors.New("transient db error"))
+
+	prov := &mockProvider{name: "docker"}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tm.HandleStale(ctx)
+
+	// Let it tick a few times under error condition.
+	time.Sleep(50 * time.Millisecond)
+
+	// Recover: clear error, populate a stale tray.
+	tray := &trays.Tray{Id: "recovered", ProviderName: "docker", Status: trays.TrayStatusCreating}
+	repo.SetStale([]*trays.Tray{tray}, nil)
+
+	assert.Eventually(t, func() bool {
+		prov.mu.Lock()
+		defer prov.mu.Unlock()
+		for _, id := range prov.cleaned {
+			if id == "recovered" {
+				return true
+			}
+		}
+		return false
+	}, 500*time.Millisecond, 10*time.Millisecond, "loop did not recover after transient error")
+
+	cancel()
+}
+
+func TestHandleStale_ContextCancellationStopsLoop(t *testing.T) {
+	config.SetForTest(t, &config.CatteryConfig{
+		Server:   config.ServerConfig{ListenAddress: ":8080", AdvertiseUrl: "http://localhost"},
+		Database: config.DatabaseConfig{Uri: "x", Database: "y"},
+		Stale: config.StaleConfig{
+			PollInterval: 10 * time.Millisecond,
+			Thresholds:   map[string]time.Duration{"creating": time.Second},
+		},
+	})
+
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{name: "docker"}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tm.HandleStale(ctx)
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	// After cancel, no further GetStale-driven activity should occur.
+	// Capture provider.cleaned snapshot, wait, verify unchanged.
+	prov.mu.Lock()
+	before := len(prov.cleaned)
+	prov.mu.Unlock()
+
+	time.Sleep(50 * time.Millisecond)
+
+	prov.mu.Lock()
+	after := len(prov.cleaned)
+	prov.mu.Unlock()
+
+	assert.Equal(t, before, after, "loop kept running after context cancellation")
+}
+
+func TestStaleConfigWithDefaults(t *testing.T) {
+	t.Run("zero values populate from defaults", func(t *testing.T) {
+		out := config.StaleConfig{}.WithDefaults()
+		assert.Equal(t, config.DefaultStalePollInterval, out.PollInterval)
+		assert.Equal(t, config.DefaultStaleThresholds, out.Thresholds)
+	})
+
+	t.Run("set values are preserved", func(t *testing.T) {
+		in := config.StaleConfig{
+			PollInterval: 30 * time.Second,
+			Thresholds: map[string]time.Duration{
+				"creating": 2 * time.Minute,
+			},
+		}
+		out := in.WithDefaults()
+		assert.Equal(t, 30*time.Second, out.PollInterval)
+		assert.Equal(t, map[string]time.Duration{"creating": 2 * time.Minute}, out.Thresholds)
+	})
+
+	t.Run("partial: only PollInterval set", func(t *testing.T) {
+		in := config.StaleConfig{PollInterval: 30 * time.Second}
+		out := in.WithDefaults()
+		assert.Equal(t, 30*time.Second, out.PollInterval)
+		assert.Equal(t, config.DefaultStaleThresholds, out.Thresholds)
+	})
 }

--- a/src/lib/trays/repositories/mongodbTrayRepository.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository.go
@@ -51,12 +51,21 @@ func (m *MongodbTrayRepository) List(ctx context.Context) ([]*trays.Tray, error)
 	return result, nil
 }
 
-func (m *MongodbTrayRepository) GetStale(ctx context.Context, d time.Duration) ([]*trays.Tray, error) {
-	dbResult, err := m.collection.Find(ctx,
-		bson.M{
-			"status":        bson.M{"$ne": trays.TrayStatusRunning},
-			"statusChanged": bson.M{"$lte": time.Now().UTC().Add(-d)},
+func (m *MongodbTrayRepository) GetStale(ctx context.Context, thresholds map[trays.TrayStatus]time.Duration) ([]*trays.Tray, error) {
+	if len(thresholds) == 0 {
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+	or := make([]bson.M, 0, len(thresholds))
+	for status, d := range thresholds {
+		or = append(or, bson.M{
+			"status":        status,
+			"statusChanged": bson.M{"$lte": now.Add(-d)},
 		})
+	}
+
+	dbResult, err := m.collection.Find(ctx, bson.M{"$or": or})
 	if err != nil {
 		return nil, err
 	}

--- a/src/lib/trays/repositories/mongodbTrayRepository_test.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository_test.go
@@ -366,8 +366,14 @@ func TestGetStale(t *testing.T) {
 	// Insert all test trays
 	insertTestTrays(t, collection, []*TestTray{staleTray1, staleTray2, freshTray1, freshTray2})
 
-	// Test GetStale with 5 minute duration
-	staleTrays, err := repo.GetStale(context.Background(),5*time.Minute)
+	// Test GetStale with 5 minute duration across all non-running statuses
+	thresholds := map[trays.TrayStatus]time.Duration{
+		trays.TrayStatusCreating:    5 * time.Minute,
+		trays.TrayStatusRegistering: 5 * time.Minute,
+		trays.TrayStatusRegistered:  5 * time.Minute,
+		trays.TrayStatusDeleting:    5 * time.Minute,
+	}
+	staleTrays, err := repo.GetStale(context.Background(), thresholds)
 	if err != nil {
 		t.Fatalf("GetStale failed: %v", err)
 	}
@@ -412,7 +418,7 @@ func TestGetStale(t *testing.T) {
 	insertTestTrays(t, collection, []*TestTray{freshTray1, freshTray2})
 
 	// Test GetStale again with 5 minute duration
-	staleTrays, err = repo.GetStale(context.Background(),5*time.Minute)
+	staleTrays, err = repo.GetStale(context.Background(), thresholds)
 	if err != nil {
 		t.Fatalf("GetStale failed: %v", err)
 	}
@@ -421,6 +427,113 @@ func TestGetStale(t *testing.T) {
 	if len(staleTrays) != 0 {
 		t.Errorf("Expected 0 stale trays, got %d", len(staleTrays))
 	}
+}
+
+// TestGetStale_PerStatusThresholds verifies that GetStale applies a different
+// threshold per status, only returning trays whose statusChanged is older than
+// the threshold for their specific status. Statuses absent from the map are
+// never returned.
+func TestGetStale_PerStatusThresholds(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	// Six trays at varying ages and statuses.
+	creatingOld := createTestTray("creating-old", "t", trays.TrayStatusCreating, 0)
+	creatingOld.StatusChanged = time.Now().UTC().Add(-6 * time.Minute)
+
+	creatingFresh := createTestTray("creating-fresh", "t", trays.TrayStatusCreating, 0)
+	creatingFresh.StatusChanged = time.Now().UTC().Add(-2 * time.Minute)
+
+	registeredOld := createTestTray("registered-old", "t", trays.TrayStatusRegistered, 0)
+	registeredOld.StatusChanged = time.Now().UTC().Add(-20 * time.Minute)
+
+	registeredMid := createTestTray("registered-mid", "t", trays.TrayStatusRegistered, 0)
+	registeredMid.StatusChanged = time.Now().UTC().Add(-6 * time.Minute)
+
+	// Status absent from threshold map — must never be returned.
+	runningAncient := createTestTray("running-ancient", "t", trays.TrayStatusRunning, 0)
+	runningAncient.StatusChanged = time.Now().UTC().Add(-1 * time.Hour)
+
+	deletingOld := createTestTray("deleting-old", "t", trays.TrayStatusDeleting, 0)
+	deletingOld.StatusChanged = time.Now().UTC().Add(-30 * time.Minute)
+
+	insertTestTrays(t, collection, []*TestTray{
+		creatingOld, creatingFresh, registeredOld, registeredMid, runningAncient, deletingOld,
+	})
+
+	// Threshold map: tight on Creating, generous on Registered, no entry for
+	// Running or Deleting (so even very old trays in those statuses are skipped).
+	thresholds := map[trays.TrayStatus]time.Duration{
+		trays.TrayStatusCreating:   5 * time.Minute,
+		trays.TrayStatusRegistered: 15 * time.Minute,
+	}
+
+	stale, err := repo.GetStale(context.Background(), thresholds)
+	if err != nil {
+		t.Fatalf("GetStale failed: %v", err)
+	}
+
+	got := make(map[string]bool, len(stale))
+	for _, tr := range stale {
+		got[tr.Id] = true
+	}
+
+	// Expected:
+	// - creating-old (6min > 5min creating threshold): match
+	// - creating-fresh (2min < 5min): no match
+	// - registered-old (20min > 15min registered threshold): match
+	// - registered-mid (6min < 15min): no match
+	// - running-ancient: status not in map, never matches
+	// - deleting-old: status not in map, never matches
+	wantMatch := []string{"creating-old", "registered-old"}
+	wantSkip := []string{"creating-fresh", "registered-mid", "running-ancient", "deleting-old"}
+
+	if len(stale) != len(wantMatch) {
+		t.Errorf("Expected %d stale trays, got %d: %v", len(wantMatch), len(stale), keysOf(got))
+	}
+	for _, id := range wantMatch {
+		if !got[id] {
+			t.Errorf("Expected %q to be in stale set, but it was missing", id)
+		}
+	}
+	for _, id := range wantSkip {
+		if got[id] {
+			t.Errorf("Expected %q to be skipped, but it was returned", id)
+		}
+	}
+}
+
+// TestGetStale_EmptyThresholds verifies that an empty threshold map returns
+// no trays without hitting the database with a malformed $or clause.
+func TestGetStale_EmptyThresholds(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	tray := createTestTray("any", "t", trays.TrayStatusCreating, 0)
+	tray.StatusChanged = time.Now().UTC().Add(-1 * time.Hour)
+	insertTestTrays(t, collection, []*TestTray{tray})
+
+	stale, err := repo.GetStale(context.Background(), map[trays.TrayStatus]time.Duration{})
+	if err != nil {
+		t.Fatalf("GetStale failed: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Errorf("Expected 0 stale trays for empty threshold map, got %d", len(stale))
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // TestNewMongodbTrayRepository tests the NewMongodbTrayRepository constructor

--- a/src/lib/trays/repositories/trayRepository.go
+++ b/src/lib/trays/repositories/trayRepository.go
@@ -13,5 +13,8 @@ type TrayRepository interface {
 	Delete(ctx context.Context, trayId string) error
 	UpdateStatus(ctx context.Context, trayId string, status trays.TrayStatus, jobRunId int64, workflowRunId int64, ghRunnerId int64, repository string, jobName string, workflowName string) (*trays.Tray, error)
 	CountActive(ctx context.Context, trayType string) (int, error)
-	GetStale(ctx context.Context, d time.Duration) ([]*trays.Tray, error)
+	// GetStale returns trays whose status is a key in thresholds and whose
+	// statusChanged is older than the corresponding duration. A status absent
+	// from the map is not checked.
+	GetStale(ctx context.Context, thresholds map[trays.TrayStatus]time.Duration) ([]*trays.Tray, error)
 }

--- a/src/lib/trays/trayStatus.go
+++ b/src/lib/trays/trayStatus.go
@@ -1,5 +1,10 @@
 package trays
 
+import (
+	"fmt"
+	"strings"
+)
+
 type TrayStatus int
 
 const (
@@ -18,6 +23,22 @@ var stateName = map[TrayStatus]string{
 	TrayStatusDeleting:    "deleting",
 }
 
+var stateByName = func() map[string]TrayStatus {
+	m := make(map[string]TrayStatus, len(stateName))
+	for s, n := range stateName {
+		m[n] = s
+	}
+	return m
+}()
+
 func (js TrayStatus) String() string {
 	return stateName[js]
+}
+
+// TrayStatusFromString parses a status name (case-insensitive) into a TrayStatus.
+func TrayStatusFromString(name string) (TrayStatus, error) {
+	if s, ok := stateByName[strings.ToLower(name)]; ok {
+		return s, nil
+	}
+	return 0, fmt.Errorf("unknown tray status %q", name)
 }

--- a/src/lib/trays/tray_test.go
+++ b/src/lib/trays/tray_test.go
@@ -28,6 +28,37 @@ func TestTrayStatusString(t *testing.T) {
 	}
 }
 
+func TestTrayStatusFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TrayStatus
+		wantErr bool
+	}{
+		{"creating", "creating", TrayStatusCreating, false},
+		{"registering", "registering", TrayStatusRegistering, false},
+		{"registered", "registered", TrayStatusRegistered, false},
+		{"running", "running", TrayStatusRunning, false},
+		{"deleting", "deleting", TrayStatusDeleting, false},
+		{"uppercase", "CREATING", TrayStatusCreating, false},
+		{"mixed case", "Registered", TrayStatusRegistered, false},
+		{"unknown", "bogus", 0, true},
+		{"empty", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TrayStatusFromString(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestTrayStatusUnknownValue(t *testing.T) {
 	unknown := TrayStatus(99)
 	assert.Equal(t, "", unknown.String())

--- a/src/server/handlers/integration_test.go
+++ b/src/server/handlers/integration_test.go
@@ -163,14 +163,23 @@ func (th *testHarness) createTray(t *testing.T) *trays.Tray {
 	require.NoError(t, err)
 	require.Equal(t, 1, active)
 
-	// Get it by listing stale with very long duration (returns all)
-	allTrays, err := th.trayRepo.GetStale(context.Background(), 999*time.Hour)
+	// Get it by listing stale with a tiny threshold (matches everything in those statuses).
+	allTrays, err := th.trayRepo.GetStale(context.Background(), allStatusesThresholds(time.Nanosecond))
 	if err != nil || len(allTrays) == 0 {
-		// GetStale might not return Creating trays; use a direct approach
-		// Create tray directly
 		t.Fatal("Could not retrieve created tray")
 	}
 	return allTrays[0]
+}
+
+// allStatusesThresholds builds a thresholds map covering every non-running
+// status with the same duration. Used in tests to fetch trays regardless of status.
+func allStatusesThresholds(d time.Duration) map[trays.TrayStatus]time.Duration {
+	return map[trays.TrayStatus]time.Duration{
+		trays.TrayStatusCreating:    d,
+		trays.TrayStatusRegistering: d,
+		trays.TrayStatusRegistered:  d,
+		trays.TrayStatusDeleting:    d,
+	}
 }
 
 // insertTray inserts a tray directly into MongoDB, preserving the StatusChanged value.
@@ -389,7 +398,9 @@ func TestIntegration_StaleTrayCleanup(t *testing.T) {
 	th.insertTray(t, tray)
 
 	// Verify tray appears in stale query
-	stale, err := th.trayRepo.GetStale(context.Background(), 2*time.Minute)
+	stale, err := th.trayRepo.GetStale(context.Background(), map[trays.TrayStatus]time.Duration{
+		trays.TrayStatusRegistering: 2 * time.Minute,
+	})
 	require.NoError(t, err)
 	require.Len(t, stale, 1)
 	assert.Equal(t, "test-type-stale-cleanup", stale[0].Id)


### PR DESCRIPTION
Per-status thresholds via new `stale:` config block

```
stale:
  pollInterval: 1m
  thresholds:
    creating: 5m
    registering: 5m
    registered: 15m
    deleting: 15m
```

All fields optional. `running` is intentionally omitted (running trays are never stale). Mongo query becomes an `$or` over per-status `{status, statusChanged ≤ now − threshold}` pairs.

fix https://github.com/paritytech/cattery/issues/51