### PR TITLE
Tray save/register race fix

### DIFF
--- a/src/agent/agent.go
+++ b/src/agent/agent.go
@@ -58,7 +58,13 @@ func (a *CatteryAgent) Start() {
 
 	agent, jitConfig, err := a.catteryClient.RegisterAgent(a.agentId)
 	if err != nil {
-		a.logger.Errorf("Failed to register agent: %v", err)
+		// The agent never managed to register. The VM is stranded — the
+		// server has no record of it (or has marked it for deletion), and
+		// nothing will pick the work up. Power off so we don't keep a spot
+		// VM running indefinitely. Stale handler cleanup on the server side
+		// will reconcile the row state.
+		a.logger.Errorf("Failed to register agent; shutting down VM: %v", err)
+		tools.Shutdown()
 		return
 	}
 	a.agent = agent

--- a/src/agent/catteryClient/client.go
+++ b/src/agent/catteryClient/client.go
@@ -9,8 +9,15 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/sirupsen/logrus"
+)
+
+// Default retry policy. Tunable via fields on CatteryClient for tests.
+const (
+	defaultMaxAttempts = 10
+	defaultRetryDelay  = 3 * time.Second
 )
 
 type CatteryClient struct {
@@ -18,60 +25,46 @@ type CatteryClient struct {
 	baseURL    string
 	logger     *logrus.Entry
 	agentId    string
+
+	// maxAttempts and retryDelay control the retry policy applied to every
+	// request. Transient failures (network errors, 5xx, 404) retry up to
+	// maxAttempts times with retryDelay between each. Permanent client
+	// errors (other 4xx) fail fast.
+	maxAttempts int
+	retryDelay  time.Duration
 }
 
 func NewCatteryClient(baseURL string, agentId string) *CatteryClient {
 	return &CatteryClient{
-		httpClient: &http.Client{},
-		baseURL:    baseURL,
-		logger:     logrus.WithField("name", "catteryClient"),
-		agentId:    agentId,
+		httpClient:  &http.Client{},
+		baseURL:     baseURL,
+		logger:      logrus.WithField("name", "catteryClient"),
+		agentId:     agentId,
+		maxAttempts: defaultMaxAttempts,
+		retryDelay:  defaultRetryDelay,
 	}
 }
 
-// RegisterAgent request just-in-time runner configuration from the Cattery server
-// and returns the configuration as a base64 encoded string
+// RegisterAgent requests just-in-time runner configuration from the Cattery
+// server. 404 retries cover the race where the agent boots before the server
+// has finished persisting the tray row.
 //
 // https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-configuration-for-a-just-in-time-runner-for-an-organization
 func (c *CatteryClient) RegisterAgent(id string) (*agents.Agent, *string, error) {
-
-	client := c.httpClient
-
 	requestUrl, err := url.JoinPath(c.baseURL, "/agent", "register/", id)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	request, err := http.NewRequest("GET", requestUrl, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	response, err := client.Do(request)
-	if err != nil {
+	var resp messages.RegisterResponse
+	if err := c.doRequest("GET", requestUrl, nil, &resp); err != nil {
 		return nil, nil, err
 	}
-
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(response.Body)
-		return nil, nil, fmt.Errorf("response status code: %s body: %s", response.Status, string(bodyBytes))
-	}
-
-	registerResponse := &messages.RegisterResponse{}
-	err = json.NewDecoder(response.Body).Decode(registerResponse)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &registerResponse.Agent, &registerResponse.JitConfig, nil
+	return &resp.Agent, &resp.JitConfig, nil
 }
 
-// UnregisterAgent sends a POST request to the Cattery server to unregister the agent
+// UnregisterAgent tells the server the agent is shutting down.
 func (c *CatteryClient) UnregisterAgent(agent *agents.Agent, reason messages.UnregisterReason, message string) error {
-
-	client := c.httpClient
-
 	requestJson, err := json.Marshal(messages.UnregisterRequest{
 		Agent:   *agent,
 		Reason:  reason,
@@ -86,53 +79,81 @@ func (c *CatteryClient) UnregisterAgent(agent *agents.Agent, reason messages.Unr
 		return err
 	}
 
-	request, err := http.NewRequest("POST", requestUrl, bytes.NewBuffer(requestJson))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	response, err := client.Do(request)
-	if err != nil {
-		return err
-	}
-
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(response.Body)
-		return fmt.Errorf("response status code: %s body: %s", response.Status, string(bodyBytes))
-	}
-
-	return nil
+	return c.doRequest("POST", requestUrl, requestJson, nil)
 }
 
 func (c *CatteryClient) Ping() (*messages.PingResponse, error) {
-
 	requestUrl, err := url.JoinPath(c.baseURL, "/agent", "ping", c.agentId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path: %w", err)
 	}
 
-	request, err := http.NewRequest("POST", requestUrl, nil)
+	pingResponse := &messages.PingResponse{}
+	if err := c.doRequest("POST", requestUrl, nil, pingResponse); err != nil {
+		return nil, err
+	}
+	return pingResponse, nil
+}
+
+// doRequest sends an HTTP request and decodes a 200 response body into dest
+// (if non-nil), retrying transient failures.
+//
+// Retryable conditions: network errors, 5xx responses, and 404 — which can
+// indicate a race against tray-row creation rather than a true "not found."
+// Permanent client errors (other 4xx) fail immediately.
+func (c *CatteryClient) doRequest(method, requestUrl string, body []byte, dest any) error {
+	var lastErr error
+	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
+		err, retryable := c.try(method, requestUrl, body, dest)
+		if err == nil {
+			return nil
+		}
+		if !retryable {
+			return err
+		}
+		lastErr = err
+		if attempt < c.maxAttempts {
+			c.logger.Warnf("%s %s attempt %d/%d failed (retrying in %s): %v", method, requestUrl, attempt, c.maxAttempts, c.retryDelay, err)
+			time.Sleep(c.retryDelay)
+		}
+	}
+	return fmt.Errorf("%s %s failed after %d attempts: %w", method, requestUrl, c.maxAttempts, lastErr)
+}
+
+// try performs a single request. The retryable flag is true when the failure
+// looks transient: network errors at any stage (including a connection drop
+// mid-body), 5xx responses, and 404. Permanent client errors (other 4xx) and
+// programming errors (bad URL/method, malformed JSON) are not retryable.
+func (c *CatteryClient) try(method, requestUrl string, body []byte, dest any) (error, bool) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	request, err := http.NewRequest(method, requestUrl, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return fmt.Errorf("failed to create request: %w", err), false
 	}
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("post error: %w", err)
+		return err, true
 	}
-
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(response.Body)
-		return nil, fmt.Errorf("response status code: %s body: %s", response.Status, string(bodyBytes))
-	}
-
-	pingResponse := &messages.PingResponse{}
-	err = json.NewDecoder(response.Body).Decode(pingResponse)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding ping response: %w", err)
+		return fmt.Errorf("read response body: %w", err), true
 	}
 
-	return pingResponse, nil
+	if response.StatusCode == http.StatusOK {
+		if dest != nil {
+			if err := json.Unmarshal(bodyBytes, dest); err != nil {
+				return fmt.Errorf("decode response body: %w", err), false
+			}
+		}
+		return nil, false
+	}
+
+	httpErr := fmt.Errorf("response status code: %s body: %s", response.Status, string(bodyBytes))
+	retryable := response.StatusCode == http.StatusNotFound || response.StatusCode >= 500
+	return httpErr, retryable
 }

--- a/src/agent/catteryClient/client_test.go
+++ b/src/agent/catteryClient/client_test.go
@@ -1,0 +1,315 @@
+package catteryClient
+
+import (
+	"cattery/lib/agents"
+	"cattery/lib/messages"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient builds a client pointed at the given test server with a
+// retry policy fast enough for unit tests.
+func newTestClient(t *testing.T, baseURL string) *CatteryClient {
+	t.Helper()
+	c := NewCatteryClient(baseURL, "test-agent")
+	c.maxAttempts = 3
+	c.retryDelay = 1 * time.Millisecond
+	return c
+}
+
+func TestRegisterAgent_Success(t *testing.T) {
+	jit := "encoded-jit-config"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/agent/register/")
+		_ = json.NewEncoder(w).Encode(messages.RegisterResponse{
+			Agent:     agents.Agent{AgentId: "test-agent", RunnerId: 42},
+			JitConfig: jit,
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	agent, jitConfig, err := c.RegisterAgent("test-agent")
+
+	require.NoError(t, err)
+	require.NotNil(t, agent)
+	assert.Equal(t, "test-agent", agent.AgentId)
+	assert.Equal(t, int64(42), agent.RunnerId)
+	require.NotNil(t, jitConfig)
+	assert.Equal(t, jit, *jitConfig)
+}
+
+func TestRegisterAgent_RetriesOn404UntilSuccess(t *testing.T) {
+	// Simulates the race: server returns 404 until the tray row lands, then 200.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			http.Error(w, "unknown agent", http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(messages.RegisterResponse{
+			Agent:     agents.Agent{AgentId: "test-agent"},
+			JitConfig: "ok",
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	agent, _, err := c.RegisterAgent("test-agent")
+
+	require.NoError(t, err)
+	require.NotNil(t, agent)
+	assert.EqualValues(t, 3, calls.Load())
+}
+
+func TestRegisterAgent_RetriesOn5xxUntilSuccess(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 2 {
+			http.Error(w, "transient", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(messages.RegisterResponse{
+			Agent: agents.Agent{AgentId: "test-agent"},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
+func TestRegisterAgent_FailsFastOn401(t *testing.T) {
+	// Authentication errors are permanent: retrying won't help.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad token", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.Error(t, err)
+	assert.EqualValues(t, 1, calls.Load(), "must not retry permanent 4xx")
+}
+
+func TestRegisterAgent_FailsFastOn400(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.Error(t, err)
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+func TestRegisterAgent_GivesUpAfterMaxAttempts(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "still missing", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL) // maxAttempts = 3
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.Error(t, err)
+	assert.EqualValues(t, 3, calls.Load())
+	assert.Contains(t, err.Error(), "after 3 attempts")
+}
+
+func TestRegisterAgent_RetriesOnNetworkError(t *testing.T) {
+	// Server that closes the connection without writing a response.
+	listener := newRefusingServer(t)
+
+	c := newTestClient(t, "http://"+listener.Addr().String())
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.Error(t, err)
+	// The retry exhausted message wraps the last network error.
+	assert.Contains(t, err.Error(), "after 3 attempts")
+}
+
+func TestRegisterAgent_RetriesOnTruncatedBody(t *testing.T) {
+	// The server returns a 200 with Content-Length set but closes the
+	// connection before sending the body. The client gets headers OK but
+	// the body read fails — that's a transient network condition, not a
+	// server bug, and must be retried.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 2 {
+			hj, ok := w.(http.Hijacker)
+			require.True(t, ok)
+			conn, _, err := hj.Hijack()
+			require.NoError(t, err)
+			_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 999\r\n\r\n"))
+			_ = conn.Close()
+			return
+		}
+		_ = json.NewEncoder(w).Encode(messages.RegisterResponse{
+			Agent: agents.Agent{AgentId: "test-agent"},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	agent, _, err := c.RegisterAgent("test-agent")
+
+	require.NoError(t, err)
+	require.NotNil(t, agent)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
+func TestRegisterAgent_FailsFastOnMalformedJSON(t *testing.T) {
+	// A 200 response with a complete but non-JSON body is a server bug.
+	// Retrying won't fix it.
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json at all"))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, _, err := c.RegisterAgent("test-agent")
+
+	require.Error(t, err)
+	assert.EqualValues(t, 1, calls.Load(), "must not retry malformed JSON")
+}
+
+func TestUnregisterAgent_Success(t *testing.T) {
+	var got messages.UnregisterRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	err := c.UnregisterAgent(&agents.Agent{AgentId: "test-agent"}, messages.UnregisterReasonDone, "job complete")
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-agent", got.Agent.AgentId)
+	assert.Equal(t, messages.UnregisterReasonDone, got.Reason)
+	assert.Equal(t, "job complete", got.Message)
+}
+
+func TestUnregisterAgent_RetriesOn5xx(t *testing.T) {
+	// Body must be re-read on each retry — verify the server sees the JSON
+	// payload on the successful attempt.
+	var calls atomic.Int32
+	var lastBody messages.UnregisterRequest
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&lastBody))
+		if calls.Add(1) < 2 {
+			http.Error(w, "boom", http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	err := c.UnregisterAgent(&agents.Agent{AgentId: "test-agent"}, messages.UnregisterReasonDone, "msg")
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, calls.Load())
+	assert.Equal(t, "test-agent", lastBody.Agent.AgentId, "request body must reach server on retry")
+}
+
+func TestPing_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		_ = json.NewEncoder(w).Encode(messages.PingResponse{Terminate: false})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	resp, err := c.Ping()
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.False(t, resp.Terminate)
+}
+
+func TestPing_RetriesOn5xx(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 2 {
+			http.Error(w, "transient", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(messages.PingResponse{Terminate: true, Message: "bye"})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	resp, err := c.Ping()
+
+	require.NoError(t, err)
+	assert.True(t, resp.Terminate)
+	assert.Equal(t, "bye", resp.Message)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
+func TestPing_FailsFastOn401(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "no auth", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, err := c.Ping()
+
+	require.Error(t, err)
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+// newRefusingServer starts a listener that accepts connections then closes
+// them immediately, producing a network error on the client side.
+func newRefusingServer(t *testing.T) net.Listener {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return l
+}

--- a/src/lib/testutil/mock_tray_repository.go
+++ b/src/lib/testutil/mock_tray_repository.go
@@ -19,6 +19,7 @@ type MockTrayRepository struct {
 	CountErr    error
 	SaveErr     error
 	UpdateErr   error
+	SetErr      error
 	DeleteErr   error
 	GetErr      error
 	StaleTrays  []*trays.Tray
@@ -90,6 +91,25 @@ func (m *MockTrayRepository) UpdateStatus(_ context.Context, trayId string, stat
 		tray.WorkflowName = workflowName
 	}
 	tray.StatusChanged = time.Now()
+	return tray, nil
+}
+
+func (m *MockTrayRepository) SetProviderData(_ context.Context, trayId string, data map[string]string) (*trays.Tray, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SetErr != nil {
+		return nil, m.SetErr
+	}
+	tray, ok := m.Trays[trayId]
+	if !ok {
+		return nil, nil
+	}
+	if tray.ProviderData == nil {
+		tray.ProviderData = make(map[string]string)
+	}
+	for k, v := range data {
+		tray.ProviderData[k] = v
+	}
 	return tray, nil
 }
 

--- a/src/lib/testutil/mock_tray_repository_test.go
+++ b/src/lib/testutil/mock_tray_repository_test.go
@@ -1,0 +1,109 @@
+package testutil
+
+import (
+	"cattery/lib/trays"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The mock is used heavily by trayManager and handler tests, and the
+// load-bearing CreateTray flow depends on its merge semantics matching the
+// Mongo impl. Lock those down here so a regression in the mock can't quietly
+// invalidate downstream test assertions.
+
+func TestMock_SetProviderData_AddsKeysToEmptyMap(t *testing.T) {
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{Id: "t1", ProviderData: map[string]string{}}
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{
+		"zone":       "us-east-1",
+		"instanceId": "i-12345",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "us-east-1", updated.ProviderData["zone"])
+	assert.Equal(t, "i-12345", updated.ProviderData["instanceId"])
+}
+
+func TestMock_SetProviderData_MergesWithoutClobbering(t *testing.T) {
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{Id: "t1", ProviderData: map[string]string{
+		"zone":       "us-east-1",
+		"instanceId": "i-original",
+	}}
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{
+		"instanceId": "i-overwritten",
+		"region":     "us-east",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", updated.ProviderData["zone"], "untouched key must survive")
+	assert.Equal(t, "i-overwritten", updated.ProviderData["instanceId"])
+	assert.Equal(t, "us-east", updated.ProviderData["region"])
+}
+
+func TestMock_SetProviderData_DoesNotChangeStatus(t *testing.T) {
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{
+		Id:           "t1",
+		Status:       trays.TrayStatusDeleting,
+		ProviderData: map[string]string{},
+	}
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{"zone": "z"})
+	require.NoError(t, err)
+	assert.Equal(t, trays.TrayStatusDeleting, updated.Status,
+		"SetProviderData must not revert a status change made by another goroutine")
+}
+
+func TestMock_SetProviderData_DoesNotBumpStatusChanged(t *testing.T) {
+	original := time.Now().Add(-10 * time.Minute)
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{
+		Id:            "t1",
+		Status:        trays.TrayStatusCreating,
+		StatusChanged: original,
+		ProviderData:  map[string]string{},
+	}
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{"zone": "z"})
+	require.NoError(t, err)
+	assert.WithinDuration(t, original, updated.StatusChanged, time.Second,
+		"statusChanged must be preserved so the stale handler's clock keeps ticking")
+}
+
+func TestMock_SetProviderData_ReturnsNilForMissingTray(t *testing.T) {
+	repo := NewMockTrayRepository()
+
+	updated, err := repo.SetProviderData(context.Background(), "missing", map[string]string{"zone": "z"})
+	require.NoError(t, err)
+	assert.Nil(t, updated)
+}
+
+func TestMock_SetProviderData_HandlesNilProviderData(t *testing.T) {
+	// Realistic case: a tray inserted directly into the mock without
+	// initializing ProviderData. The mock must treat nil as empty rather
+	// than panicking on map write.
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{Id: "t1", ProviderData: nil}
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{"zone": "z"})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "z", updated.ProviderData["zone"])
+}
+
+func TestMock_SetProviderData_RespectsSetErr(t *testing.T) {
+	repo := NewMockTrayRepository()
+	repo.Trays["t1"] = &trays.Tray{Id: "t1", ProviderData: map[string]string{}}
+	repo.SetErr = errors.New("simulated db error")
+
+	updated, err := repo.SetProviderData(context.Background(), "t1", map[string]string{"zone": "z"})
+	require.Error(t, err)
+	assert.Nil(t, updated)
+}

--- a/src/lib/trayManager/trayManager.go
+++ b/src/lib/trayManager/trayManager.go
@@ -81,6 +81,18 @@ func (tm *TrayManager) logCreationResults(trayTypeName string, results []error) 
 	return nil
 }
 
+// CreateTray reserves a tray row before any provider call so that an agent
+// booting on the new VM can register against an existing record. The deploy
+// runs in two phases:
+//
+//  1. StartDeploy submits the create request and populates tray.ProviderData
+//     with cleanup-relevant fields. We persist that data immediately so a
+//     crash during WaitDeploy still leaves enough info for cleanup.
+//
+//  2. WaitDeploy blocks until the resource is ready. Concurrent unregisters
+//     during either phase flip the row to TrayStatusDeleting; we observe
+//     that on the post-WaitDeploy persist and trigger cleanup. We don't
+//     check status mid-deploy — at worst we waste the wait phase.
 func (tm *TrayManager) CreateTray(ctx context.Context, trayType *config.TrayType) error {
 	provider, err := tm.providerFactory.GetProvider(trayType.Provider)
 	if err != nil {
@@ -92,21 +104,40 @@ func (tm *TrayManager) CreateTray(ctx context.Context, trayType *config.TrayType
 		return err
 	}
 
-	err = provider.RunTray(tray)
-	if err != nil {
-		log.Errorf("Failed to run tray for provider '%s', tray '%s': %v", trayType.Provider, tray.Id, err)
+	if err := tm.trayRepository.Save(ctx, tray); err != nil {
+		return fmt.Errorf("failed to save tray %s: %w", tray.Id, err)
+	}
+
+	if err := provider.StartDeploy(ctx, tray); err != nil {
+		log.Errorf("Failed start deploy for tray %s: %v", tray.Id, err)
 		metrics.TrayProviderErrors(tray.GitHubOrgName, tray.ProviderName, tray.TrayTypeName, "create")
+		if _, dErr := tm.DeleteTray(ctx, tray.Id); dErr != nil {
+			log.Errorf("Failed to delete tray %s after start deploy error: %v", tray.Id, dErr)
+		}
 		return err
 	}
 
-	err = tm.trayRepository.Save(ctx, tray)
-	if err != nil {
-		log.Errorf("Failed to save tray %s: %v — cleaning up provider resource", trayType.Name, err)
-		if cleanErr := provider.CleanTray(tray); cleanErr != nil {
-			log.Errorf("Failed to clean up tray %s after save failure: %v", tray.Id, cleanErr)
-			metrics.TrayProviderErrors(tray.GitHubOrgName, tray.ProviderName, tray.TrayTypeName, "delete")
+	if _, err := tm.trayRepository.SetProviderData(ctx, tray.Id, tray.ProviderData); err != nil {
+		log.Errorf("Failed to persist provider data for tray %s: %v", tray.Id, err)
+	}
+
+	waitErr := provider.WaitDeploy(ctx, tray)
+	merged, _ := tm.trayRepository.SetProviderData(ctx, tray.Id, tray.ProviderData)
+
+	if waitErr != nil {
+		log.Errorf("Failed wait deploy for tray %s: %v", tray.Id, waitErr)
+		metrics.TrayProviderErrors(tray.GitHubOrgName, tray.ProviderName, tray.TrayTypeName, "create")
+		if _, dErr := tm.DeleteTray(ctx, tray.Id); dErr != nil {
+			log.Errorf("Failed to delete tray %s after wait deploy error: %v", tray.Id, dErr)
 		}
-		return fmt.Errorf("failed to save tray %s: %w", trayType.Name, err)
+		return waitErr
+	}
+
+	if merged != nil && merged.Status == trays.TrayStatusDeleting {
+		log.Infof("Tray %s marked for deletion during deploy; cleaning up", tray.Id)
+		if _, dErr := tm.DeleteTray(ctx, tray.Id); dErr != nil {
+			log.Errorf("Failed to delete tray %s after concurrent unregister: %v", tray.Id, dErr)
+		}
 	}
 
 	return nil
@@ -154,6 +185,11 @@ func (tm *TrayManager) SetJob(ctx context.Context, trayId string, jobRunId int64
 	return tray, nil
 }
 
+// DeleteTray marks the tray as deleting and attempts to clean up the
+// upstream resource. On cleanup failure the row is left in deleting state for
+// the stale handler to retry; only repository-level failures propagate to the
+// caller. Callers (unregister handler, stale loop) should treat a non-error
+// return as "deletion was requested," not "the upstream resource is gone."
 func (tm *TrayManager) DeleteTray(ctx context.Context, trayId string) (*trays.Tray, error) {
 	tray, err := tm.trayRepository.UpdateStatus(ctx, trayId, trays.TrayStatusDeleting, 0, 0, 0, "", "", "")
 	if err != nil {
@@ -165,19 +201,18 @@ func (tm *TrayManager) DeleteTray(ctx context.Context, trayId string) (*trays.Tr
 
 	provider, err := tm.providerFactory.GetProviderForTray(tray)
 	if err != nil {
-		return nil, err
+		log.Errorf("Failed to get provider for tray %s: %v; leaving for stale handler", tray.Id, err)
+		return tray, nil
 	}
 
-	err = provider.CleanTray(tray)
-	if err != nil {
-		log.Errorf("Failed to delete tray for provider %s, tray %s: %v", provider.GetProviderName(), tray.Id, err)
+	if err := provider.CleanTray(ctx, tray); err != nil {
+		log.Errorf("Failed to clean tray %s; leaving for stale handler: %v", tray.Id, err)
 		metrics.TrayProviderErrors(tray.GitHubOrgName, tray.ProviderName, tray.TrayTypeName, "delete")
-		return nil, err
+		return tray, nil
 	}
 
-	err = tm.trayRepository.Delete(ctx, trayId)
-	if err != nil {
-		return nil, err
+	if err := tm.trayRepository.Delete(ctx, trayId); err != nil {
+		return tray, err
 	}
 
 	return tray, nil

--- a/src/lib/trayManager/trayManager_test.go
+++ b/src/lib/trayManager/trayManager_test.go
@@ -17,22 +17,47 @@ import (
 // --- Mock provider ---
 
 type mockProvider struct {
-	mu       sync.Mutex
-	name     string
-	runErr   error
-	cleanErr error
-	runCalls int
-	cleaned  []string
+	mu         sync.Mutex
+	name       string
+	startErr   error
+	waitErr    error
+	cleanErr   error
+	startCalls int
+	waitCalls  int
+	cleaned    []string
+	// onStart, if set, is called inside StartDeploy so tests can mutate state
+	// (e.g. simulate a concurrent unregister) before the manager persists
+	// provider data.
+	onStart func(*trays.Tray)
+	// onWait, if set, is called inside WaitDeploy. Useful for asserting on
+	// state observed between StartDeploy and WaitDeploy from the manager's
+	// point of view.
+	onWait func(*trays.Tray)
 }
 
 func (m *mockProvider) GetProviderName() string { return m.name }
-func (m *mockProvider) RunTray(_ *trays.Tray) error {
+func (m *mockProvider) StartDeploy(_ context.Context, tray *trays.Tray) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.runCalls++
-	return m.runErr
+	m.startCalls++
+	cb := m.onStart
+	m.mu.Unlock()
+	if cb != nil {
+		cb(tray)
+	}
+	return m.startErr
 }
-func (m *mockProvider) CleanTray(tray *trays.Tray) error {
+func (m *mockProvider) WaitDeploy(_ context.Context, tray *trays.Tray) error {
+	m.mu.Lock()
+	m.waitCalls++
+	cb := m.onWait
+	err := m.waitErr
+	m.mu.Unlock()
+	if cb != nil {
+		cb(tray)
+	}
+	return err
+}
+func (m *mockProvider) CleanTray(_ context.Context, tray *trays.Tray) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.cleaned = append(m.cleaned, tray.Id)
@@ -139,7 +164,7 @@ func TestScaleForDemand_ScalesUp(t *testing.T) {
 
 	err := tm.ScaleForDemand(context.Background(), trayType, 5)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, prov.runCalls)
+	assert.Equal(t, 3, prov.startCalls)
 }
 
 func TestScaleForDemand_CappedByMaxTrays(t *testing.T) {
@@ -156,7 +181,7 @@ func TestScaleForDemand_CappedByMaxTrays(t *testing.T) {
 
 	err := tm.ScaleForDemand(context.Background(), trayType, 20)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, prov.runCalls)
+	assert.Equal(t, 2, prov.startCalls)
 }
 
 func TestCreateTray_Success(t *testing.T) {
@@ -172,13 +197,35 @@ func TestCreateTray_Success(t *testing.T) {
 
 	err := tm.CreateTray(context.Background(), trayType)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, prov.runCalls)
+	assert.Equal(t, 1, prov.startCalls)
+	assert.Equal(t, 1, prov.waitCalls)
 	assert.Equal(t, 1, len(repo.Trays))
 }
 
-func TestCreateTray_ProviderError(t *testing.T) {
+func TestCreateTray_RowExistsBeforeProviderCall(t *testing.T) {
+	// The whole point of save-before-deploy: when StartDeploy runs, the row
+	// must already be in the repository, so an agent registering against a
+	// fast-booting VM finds something.
 	repo := testutil.NewMockTrayRepository()
-	prov := &mockProvider{name: "docker", runErr: errors.New("docker failed")}
+	prov := &mockProvider{
+		name: "docker",
+		onStart: func(tray *trays.Tray) {
+			// Simulate the agent's registration handler running while StartDeploy
+			// is still in flight. It must see the row.
+			got, _ := repo.GetById(context.Background(), tray.Id)
+			assert.NotNil(t, got, "tray row must exist before StartDeploy completes")
+		},
+	}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{Name: "test-type", Provider: "docker", GitHubOrg: "test-org"}
+	err := tm.CreateTray(context.Background(), trayType)
+	assert.NoError(t, err)
+}
+
+func TestCreateTray_StartDeployError_CleansUp(t *testing.T) {
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{name: "docker", startErr: errors.New("docker failed")}
 	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
 
 	trayType := &config.TrayType{
@@ -189,10 +236,128 @@ func TestCreateTray_ProviderError(t *testing.T) {
 
 	err := tm.CreateTray(context.Background(), trayType)
 	assert.Error(t, err)
+	// StartDeploy failure triggers cleanup; on successful clean the row is
+	// deleted. WaitDeploy should not run after a StartDeploy error.
+	assert.Equal(t, 0, prov.waitCalls)
+	assert.Equal(t, 1, len(prov.cleaned))
 	assert.Equal(t, 0, len(repo.Trays))
 }
 
-func TestCreateTray_SaveError_CleansUp(t *testing.T) {
+func TestCreateTray_StartDeployError_CleanupFails_RowStays(t *testing.T) {
+	// When the deploy fails AND cleanup also fails, the row must remain in
+	// "deleting" status so the stale handler retries it.
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{
+		name:     "docker",
+		startErr: errors.New("docker failed"),
+		cleanErr: errors.New("clean also failed"),
+	}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{
+		Name:      "test-type",
+		Provider:  "docker",
+		GitHubOrg: "test-org",
+	}
+
+	err := tm.CreateTray(context.Background(), trayType)
+	assert.Error(t, err)
+	assert.Equal(t, 1, len(repo.Trays))
+	for _, tr := range repo.Trays {
+		assert.Equal(t, trays.TrayStatusDeleting, tr.Status, "row should be left in deleting state for the stale handler")
+	}
+}
+
+func TestCreateTray_ConcurrentDelete_TriggersCleanup(t *testing.T) {
+	// If an unregister arrives while a deploy is running, the persist that
+	// follows WaitDeploy observes status=deleting and cleanup runs without
+	// waiting for the stale handler. WaitDeploy itself is still allowed to
+	// run — we accept that wasted wait in exchange for a simpler flow.
+	repo := testutil.NewMockTrayRepository()
+	var trayId string
+	prov := &mockProvider{name: "docker"}
+	prov.onStart = func(tray *trays.Tray) {
+		trayId = tray.Id
+		// Simulate a concurrent unregister flipping status to deleting.
+		_, _ = repo.UpdateStatus(context.Background(), tray.Id, trays.TrayStatusDeleting, 0, 0, 0, "", "", "")
+	}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{Name: "test-type", Provider: "docker", GitHubOrg: "test-org"}
+	err := tm.CreateTray(context.Background(), trayType)
+
+	assert.NoError(t, err, "concurrent delete handled inline is not an error to the caller")
+	assert.NotEmpty(t, trayId)
+	assert.Equal(t, 1, len(prov.cleaned))
+	assert.Equal(t, 0, len(repo.Trays))
+}
+
+func TestCreateTray_WaitDeployError_CleansUp(t *testing.T) {
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{name: "docker", waitErr: errors.New("vm never ready")}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{Name: "test-type", Provider: "docker", GitHubOrg: "test-org"}
+	err := tm.CreateTray(context.Background(), trayType)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, prov.startCalls)
+	assert.Equal(t, 1, prov.waitCalls)
+	assert.Equal(t, 1, len(prov.cleaned))
+	assert.Equal(t, 0, len(repo.Trays))
+}
+
+func TestCreateTray_WaitDeployError_CleanupFails_RowStays(t *testing.T) {
+	// Symmetric to TestCreateTray_StartDeployError_CleanupFails_RowStays:
+	// a wait-phase failure with cleanup also failing must leave the row in
+	// "deleting" state for the stale handler to retry.
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{
+		name:     "docker",
+		waitErr:  errors.New("vm never ready"),
+		cleanErr: errors.New("clean also failed"),
+	}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{Name: "test-type", Provider: "docker", GitHubOrg: "test-org"}
+	err := tm.CreateTray(context.Background(), trayType)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, len(repo.Trays))
+	for _, tr := range repo.Trays {
+		assert.Equal(t, trays.TrayStatusDeleting, tr.Status)
+	}
+}
+
+func TestCreateTray_StartDeployData_PersistedBeforeWait(t *testing.T) {
+	// Crash-safety guarantee: anything StartDeploy puts in tray.ProviderData
+	// must be persisted to the repository before WaitDeploy starts blocking.
+	// Otherwise a server crash mid-wait leaves a real VM running with no
+	// cleanup handle in the database.
+	repo := testutil.NewMockTrayRepository()
+	prov := &mockProvider{name: "docker"}
+	prov.onStart = func(tray *trays.Tray) {
+		tray.ProviderData["zone"] = "us-east-1"
+		tray.ProviderData["instanceId"] = "i-12345"
+	}
+	prov.onWait = func(tray *trays.Tray) {
+		// By the time WaitDeploy runs, the provider data populated in
+		// StartDeploy must be visible in the repository.
+		got, _ := repo.GetById(context.Background(), tray.Id)
+		assert.NotNil(t, got)
+		assert.Equal(t, "us-east-1", got.ProviderData["zone"])
+		assert.Equal(t, "i-12345", got.ProviderData["instanceId"])
+	}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	trayType := &config.TrayType{Name: "test-type", Provider: "docker", GitHubOrg: "test-org"}
+	err := tm.CreateTray(context.Background(), trayType)
+	assert.NoError(t, err)
+}
+
+func TestCreateTray_InitialSaveError(t *testing.T) {
+	// With save-before-deploy, an initial Save failure means no provider
+	// resource was ever requested — nothing to clean up.
 	repo := testutil.NewMockTrayRepository()
 	repo.SaveErr = errors.New("db error")
 	prov := &mockProvider{name: "docker"}
@@ -206,7 +371,8 @@ func TestCreateTray_SaveError_CleansUp(t *testing.T) {
 
 	err := tm.CreateTray(context.Background(), trayType)
 	assert.Error(t, err)
-	assert.Equal(t, 1, len(prov.cleaned))
+	assert.Equal(t, 0, prov.startCalls)
+	assert.Equal(t, 0, len(prov.cleaned))
 }
 
 func TestCreateTray_FactoryError(t *testing.T) {
@@ -250,26 +416,36 @@ func TestDeleteTray_NotFound(t *testing.T) {
 }
 
 func TestDeleteTray_ProviderCleanError(t *testing.T) {
+	// Cleanup failure is logged and swallowed: the row stays in "deleting"
+	// state so the stale handler can retry, and the caller (typically the
+	// unregister HTTP handler) gets a soft success.
 	repo := testutil.NewMockTrayRepository()
 	repo.Trays["tray-1"] = &trays.Tray{Id: "tray-1", TrayTypeName: "test-type"}
 	prov := &mockProvider{name: "docker", cleanErr: errors.New("clean failed")}
 	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
 
 	tray, err := tm.DeleteTray(context.Background(), "tray-1")
-	assert.Error(t, err)
-	assert.Nil(t, tray)
+	assert.NoError(t, err)
+	assert.NotNil(t, tray)
 	assert.Equal(t, 1, len(repo.Trays))
+	assert.Equal(t, trays.TrayStatusDeleting, repo.Trays["tray-1"].Status)
 }
 
 func TestDeleteTray_FactoryError(t *testing.T) {
+	// Provider config missing for this tray's type — log it, leave the row
+	// in deleting for the stale handler to keep trying. Don't fail the
+	// caller; an unregister request shouldn't return 500 to an agent that's
+	// already shutting down.
 	repo := testutil.NewMockTrayRepository()
 	repo.Trays["tray-1"] = &trays.Tray{Id: "tray-1", TrayTypeName: "test-type"}
 	factory := &mockProviderFactory{forTrayErr: errors.New("no provider")}
 	tm := newTestManager(repo, factory)
 
 	tray, err := tm.DeleteTray(context.Background(), "tray-1")
-	assert.Error(t, err)
-	assert.Nil(t, tray)
+	assert.NoError(t, err)
+	assert.NotNil(t, tray)
+	assert.Equal(t, 1, len(repo.Trays))
+	assert.Equal(t, trays.TrayStatusDeleting, repo.Trays["tray-1"].Status)
 }
 
 func TestGetTrayById_Found(t *testing.T) {

--- a/src/lib/trayManager/trayManager_test.go
+++ b/src/lib/trayManager/trayManager_test.go
@@ -431,6 +431,39 @@ func TestDeleteTray_ProviderCleanError(t *testing.T) {
 	assert.Equal(t, trays.TrayStatusDeleting, repo.Trays["tray-1"].Status)
 }
 
+func TestDeleteTray_RepoDeleteFails_Propagates(t *testing.T) {
+	// Cleanup succeeded, but the repository's Delete call failed. This is a
+	// genuine repo-level failure (DB blip) and must propagate to the caller
+	// so the upstream layer can react. The row remains in deleting status —
+	// the stale handler will try again next tick.
+	repo := testutil.NewMockTrayRepository()
+	repo.Trays["tray-1"] = &trays.Tray{Id: "tray-1", TrayTypeName: "test-type"}
+	repo.DeleteErr = errors.New("db transient error")
+	prov := &mockProvider{name: "docker"}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	tray, err := tm.DeleteTray(context.Background(), "tray-1")
+	assert.Error(t, err)
+	assert.NotNil(t, tray, "tray returned even when row delete fails so callers can log the id")
+	assert.Equal(t, 1, len(prov.cleaned), "cleanup ran successfully")
+	assert.Equal(t, 1, len(repo.Trays), "row remains for stale handler retry")
+}
+
+func TestDeleteTray_UpdateStatusFails_Propagates(t *testing.T) {
+	// If we can't even mark the row as deleting, propagate immediately —
+	// there's no way to make progress. CleanTray should not run.
+	repo := testutil.NewMockTrayRepository()
+	repo.Trays["tray-1"] = &trays.Tray{Id: "tray-1", TrayTypeName: "test-type"}
+	repo.UpdateErr = errors.New("db error")
+	prov := &mockProvider{name: "docker"}
+	tm := newTestManager(repo, &mockProviderFactory{provider: prov})
+
+	tray, err := tm.DeleteTray(context.Background(), "tray-1")
+	assert.Error(t, err)
+	assert.Nil(t, tray)
+	assert.Equal(t, 0, len(prov.cleaned), "must not attempt cleanup if status couldn't be marked")
+}
+
 func TestDeleteTray_FactoryError(t *testing.T) {
 	// Provider config missing for this tray's type — log it, leave the row
 	// in deleting for the stale handler to keep trying. Don't fail the

--- a/src/lib/trays/providers/dockerProvider.go
+++ b/src/lib/trays/providers/dockerProvider.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"cattery/lib/config"
 	"cattery/lib/trays"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -33,8 +34,10 @@ func (d *DockerProvider) GetProviderName() string {
 	return d.name
 }
 
-func (d *DockerProvider) RunTray(tray *trays.Tray) error {
-
+// StartDeploy launches the container in detached mode. The container name is
+// the trayId, which is the only handle CleanTray needs. `docker run -d`
+// returns once the container is started, so there is no separate wait phase.
+func (d *DockerProvider) StartDeploy(ctx context.Context, tray *trays.Tray) error {
 	containerName := tray.Id
 
 	trayConfig, ok := tray.TrayConfig().(config.DockerTrayConfig)
@@ -45,7 +48,7 @@ func (d *DockerProvider) RunTray(tray *trays.Tray) error {
 	image := trayConfig.Image
 	serverUrl := config.Get().Server.AdvertiseUrl
 
-	dockerCommand := exec.Command("docker", "run", "-d", "--rm",
+	dockerCommand := exec.CommandContext(ctx, "docker", "run", "-d", "--rm",
 		"--add-host=host.docker.internal:host-gateway",
 		"--name", containerName,
 		image,
@@ -62,8 +65,12 @@ func (d *DockerProvider) RunTray(tray *trays.Tray) error {
 	return nil
 }
 
-func (d *DockerProvider) CleanTray(tray *trays.Tray) error {
-	dockerCommand := exec.Command("docker", "container", "stop", tray.Id)
+func (d *DockerProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error {
+	return nil
+}
+
+func (d *DockerProvider) CleanTray(ctx context.Context, tray *trays.Tray) error {
+	dockerCommand := exec.CommandContext(ctx, "docker", "container", "stop", tray.Id)
 	dockerCommandOutput, err := dockerCommand.CombinedOutput()
 	if err != nil {
 		output := string(dockerCommandOutput)

--- a/src/lib/trays/providers/gceProvider.go
+++ b/src/lib/trays/providers/gceProvider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"sync"
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
@@ -21,7 +22,14 @@ type GceProvider struct {
 	providerConfig config.ProviderConfig
 
 	instanceClient *compute.InstancesClient
-	logger         *logrus.Entry
+
+	// pendingOps tracks insert operations between StartDeploy and WaitDeploy.
+	// Lost on process restart, which is acceptable: the row in the repository
+	// has zone+name, so the stale handler can still clean up the VM if the
+	// agent never registers.
+	pendingOps sync.Map // map[trayId]*compute.Operation
+
+	logger *logrus.Entry
 }
 
 func NewGceProvider(name string, providerConfig config.ProviderConfig) *GceProvider {
@@ -51,17 +59,26 @@ func (g *GceProvider) Close() error {
 	return nil
 }
 
-func (g *GceProvider) RunTray(tray *trays.Tray) error {
-	ctx := context.Background()
-
+// StartDeploy submits the Insert request to GCE. The chosen zone is written to
+// ProviderData *before* the API call so that even an Insert failure leaves
+// enough data to attempt cleanup (which may no-op against a 404). The returned
+// operation handle is stashed for WaitDeploy.
+func (g *GceProvider) StartDeploy(ctx context.Context, tray *trays.Tray) error {
 	trayConfig, ok := tray.TrayConfig().(config.GoogleTrayConfig)
 	if !ok {
 		return fmt.Errorf("unexpected tray config type for gce provider, tray %s", tray.Id)
 	}
 
+	zones := trayConfig.Zones
+	if len(zones) == 0 {
+		return fmt.Errorf("no zones configured for tray %s", tray.Id)
+	}
+	zone := zones[rand.Intn(len(zones))]
+
+	tray.ProviderData["zone"] = zone
+
 	project := g.providerConfig.Get("project")
 	instanceTemplate := trayConfig.InstanceTemplate
-	zones := trayConfig.Zones
 	machineType := trayConfig.MachineType
 
 	var extraMetadata config.TrayExtraMetadata
@@ -77,12 +94,6 @@ func (g *GceProvider) RunTray(tray *trays.Tray) error {
 		extraMetadata,
 	)
 
-	if len(zones) == 0 {
-		return fmt.Errorf("no zones configured for tray %s", tray.Id)
-	}
-
-	var zone = zones[rand.Intn(len(zones))]
-
 	op, err := g.instanceClient.Insert(ctx, &computepb.InsertInstanceRequest{
 		Project:                project,
 		Zone:                   zone,
@@ -94,30 +105,49 @@ func (g *GceProvider) RunTray(tray *trays.Tray) error {
 		},
 	})
 	if err != nil {
-		g.logger.Errorf("Failed to create tray: %v", err)
+		g.logger.Errorf("Failed to start tray creation: %v", err)
 		return err
 	}
 
+	g.pendingOps.Store(tray.Id, op)
+	return nil
+}
+
+// WaitDeploy blocks until the create operation completes. If no operation is
+// tracked locally (e.g. process restart between StartDeploy and WaitDeploy),
+// it returns nil — the agent registration path or the stale handler will
+// resolve the eventual outcome.
+func (g *GceProvider) WaitDeploy(ctx context.Context, tray *trays.Tray) error {
+	v, ok := g.pendingOps.LoadAndDelete(tray.Id)
+	if !ok {
+		g.logger.Tracef("No pending operation for tray %s; skipping wait", tray.Id)
+		return nil
+	}
+	op := v.(*compute.Operation)
 	if err := op.Wait(ctx); err != nil {
 		g.logger.Errorf("Failed waiting for tray creation to complete: %v", err)
 		return err
 	}
-
-	tray.ProviderData["zone"] = zone
-
 	return nil
 }
 
-func (g *GceProvider) CleanTray(tray *trays.Tray) error {
+func (g *GceProvider) CleanTray(ctx context.Context, tray *trays.Tray) error {
+	g.pendingOps.Delete(tray.Id)
+
+	zone := tray.ProviderData["zone"]
+	if zone == "" {
+		g.logger.Warnf("CleanTray called without zone for tray %s; nothing to delete", tray.Id)
+		return nil
+	}
+
 	client, err := g.createInstancesClient()
 	if err != nil {
 		return err
 	}
 
-	zone := tray.ProviderData["zone"]
 	project := g.providerConfig.Get("project")
 
-	_, err = client.Delete(context.Background(), &computepb.DeleteInstanceRequest{
+	_, err = client.Delete(ctx, &computepb.DeleteInstanceRequest{
 		Instance: tray.Id,
 		Project:  project,
 		Zone:     zone,

--- a/src/lib/trays/providers/trayProvider.go
+++ b/src/lib/trays/providers/trayProvider.go
@@ -2,16 +2,32 @@ package providers
 
 import (
 	"cattery/lib/trays"
+	"context"
 )
 
+// TrayProvider models a two-phase deployment lifecycle:
+//
+//   - StartDeploy submits the create request to the upstream provider and
+//     populates tray.ProviderData with whatever the cleanup path needs (zone,
+//     resource ID, etc.). It must return as soon as the provider has accepted
+//     the request, NOT after the resource is fully ready. If StartDeploy
+//     returns an error, it must still populate ProviderData with whatever
+//     cleanup data is known, since the resource may have been partially
+//     created.
+//
+//   - WaitDeploy blocks until the resource is reachable. May be interrupted by
+//     ctx cancellation. Some providers (e.g. local Docker) may treat this as a
+//     no-op.
+//
+//   - CleanTray removes the upstream resource using only fields stored in
+//     tray.ProviderData. It MUST be safe to call on a tray that StartDeploy
+//     never finished — i.e. given partial ProviderData.
 type TrayProvider interface {
 	GetProviderName() string
 
-	// RunTray spawns a new tray.
-	RunTray(tray *trays.Tray) error
-
-	// CleanTray deletes the tray with the given ID.
-	CleanTray(tray *trays.Tray) error
+	StartDeploy(ctx context.Context, tray *trays.Tray) error
+	WaitDeploy(ctx context.Context, tray *trays.Tray) error
+	CleanTray(ctx context.Context, tray *trays.Tray) error
 }
 
 // TrayProviderFactory resolves providers by name or by tray.

--- a/src/lib/trays/repositories/mongodbTrayRepository.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository.go
@@ -134,6 +134,33 @@ func (m *MongodbTrayRepository) UpdateStatus(ctx context.Context, trayId string,
 	return &result, nil
 }
 
+func (m *MongodbTrayRepository) SetProviderData(ctx context.Context, trayId string, data map[string]string) (*trays.Tray, error) {
+	if len(data) == 0 {
+		return m.GetById(ctx, trayId)
+	}
+
+	setQuery := bson.M{}
+	for k, v := range data {
+		setQuery["providerData."+k] = v
+	}
+
+	dbResult := m.collection.FindOneAndUpdate(
+		ctx,
+		bson.M{"id": trayId},
+		bson.M{"$set": setQuery},
+		options.FindOneAndUpdate().SetReturnDocument(options.After))
+
+	var result trays.Tray
+	err := dbResult.Decode(&result)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (m *MongodbTrayRepository) Delete(ctx context.Context, trayId string) error {
 	_, err := m.collection.DeleteOne(ctx, bson.M{"id": trayId})
 	return err

--- a/src/lib/trays/repositories/mongodbTrayRepository_test.go
+++ b/src/lib/trays/repositories/mongodbTrayRepository_test.go
@@ -536,6 +536,214 @@ func keysOf(m map[string]bool) []string {
 	return out
 }
 
+// TestSetProviderData_AddsKeysToEmptyMap verifies that SetProviderData
+// inserts new keys when the row's providerData was empty.
+func TestSetProviderData_AddsKeysToEmptyMap(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	trayType := config.TrayType{
+		Name:          "test-type",
+		Provider:      "google",
+		RunnerGroupId: 1,
+		GitHubOrg:     "test-org",
+		Config:        &config.DockerTrayConfig{Image: "alpine", NamePrefix: "x"},
+	}
+	tray, err := trays.NewTray(trayType)
+	if err != nil {
+		t.Fatalf("NewTray failed: %v", err)
+	}
+	if err := repo.Save(context.Background(), tray); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	updated, err := repo.SetProviderData(context.Background(), tray.Id, map[string]string{
+		"zone":       "us-east-1",
+		"instanceId": "i-12345",
+	})
+	if err != nil {
+		t.Fatalf("SetProviderData failed: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("SetProviderData returned nil tray")
+	}
+	if updated.ProviderData["zone"] != "us-east-1" {
+		t.Errorf("Expected zone=us-east-1, got %q", updated.ProviderData["zone"])
+	}
+	if updated.ProviderData["instanceId"] != "i-12345" {
+		t.Errorf("Expected instanceId=i-12345, got %q", updated.ProviderData["instanceId"])
+	}
+}
+
+// TestSetProviderData_MergesWithoutClobbering verifies that calling
+// SetProviderData twice with overlapping keys preserves untouched keys and
+// updates only the supplied ones.
+func TestSetProviderData_MergesWithoutClobbering(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	trayType := config.TrayType{
+		Name:          "test-type",
+		Provider:      "google",
+		RunnerGroupId: 1,
+		GitHubOrg:     "test-org",
+		Config:        &config.DockerTrayConfig{Image: "alpine", NamePrefix: "x"},
+	}
+	tray, err := trays.NewTray(trayType)
+	if err != nil {
+		t.Fatalf("NewTray failed: %v", err)
+	}
+	if err := repo.Save(context.Background(), tray); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if _, err := repo.SetProviderData(context.Background(), tray.Id, map[string]string{
+		"zone":       "us-east-1",
+		"instanceId": "i-original",
+	}); err != nil {
+		t.Fatalf("first SetProviderData failed: %v", err)
+	}
+
+	updated, err := repo.SetProviderData(context.Background(), tray.Id, map[string]string{
+		"instanceId": "i-overwritten",
+		"region":     "us-east",
+	})
+	if err != nil {
+		t.Fatalf("second SetProviderData failed: %v", err)
+	}
+
+	if updated.ProviderData["zone"] != "us-east-1" {
+		t.Errorf("Expected zone untouched (us-east-1), got %q", updated.ProviderData["zone"])
+	}
+	if updated.ProviderData["instanceId"] != "i-overwritten" {
+		t.Errorf("Expected instanceId=i-overwritten, got %q", updated.ProviderData["instanceId"])
+	}
+	if updated.ProviderData["region"] != "us-east" {
+		t.Errorf("Expected region=us-east, got %q", updated.ProviderData["region"])
+	}
+}
+
+// TestSetProviderData_DoesNotChangeStatus is the load-bearing invariant:
+// a concurrent unregister flips status to deleting; a SetProviderData call
+// from the deploy path must NOT revert that. The post-deploy status check
+// in CreateTray relies on this.
+func TestSetProviderData_DoesNotChangeStatus(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	tray := createTestTray("test-tray-1", "test-type", trays.TrayStatusCreating, 0)
+	insertTestTrays(t, collection, []*TestTray{tray})
+
+	// Simulate a concurrent unregister flipping status to deleting.
+	if _, err := repo.UpdateStatus(context.Background(), "test-tray-1", trays.TrayStatusDeleting, 0, 0, 0, "", "", ""); err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	// Now the deploy goroutine, oblivious to the unregister, persists
+	// provider data. SetProviderData must not revert the status.
+	updated, err := repo.SetProviderData(context.Background(), "test-tray-1", map[string]string{
+		"zone": "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("SetProviderData failed: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("SetProviderData returned nil tray")
+	}
+	if updated.Status != trays.TrayStatusDeleting {
+		t.Errorf("Expected status=deleting (untouched), got %v", updated.Status)
+	}
+	if updated.ProviderData["zone"] != "us-east-1" {
+		t.Errorf("Expected zone=us-east-1 to be set, got %q", updated.ProviderData["zone"])
+	}
+}
+
+// TestSetProviderData_DoesNotBumpStatusChanged verifies that a merge call
+// does not refresh statusChanged. The stale handler relies on the timestamp
+// to age trays; if every deploy-time merge bumped it, stale cleanup would
+// effectively never fire.
+func TestSetProviderData_DoesNotBumpStatusChanged(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	originalChanged := time.Now().UTC().Add(-10 * time.Minute)
+	tray := createTestTray("test-tray-1", "test-type", trays.TrayStatusCreating, 0)
+	tray.StatusChanged = originalChanged
+	insertTestTrays(t, collection, []*TestTray{tray})
+
+	updated, err := repo.SetProviderData(context.Background(), "test-tray-1", map[string]string{
+		"zone": "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("SetProviderData failed: %v", err)
+	}
+
+	// Allow a small skew for clock granularity. Anything within a few seconds
+	// of the original timestamp means SetProviderData didn't refresh it.
+	delta := updated.StatusChanged.Sub(originalChanged)
+	if delta < -time.Second || delta > time.Second {
+		t.Errorf("Expected statusChanged unchanged (≈%v), got %v (delta %v)",
+			originalChanged, updated.StatusChanged, delta)
+	}
+}
+
+// TestSetProviderData_ReturnsNilForMissingTray verifies the (nil, nil)
+// contract for missing rows. CreateTray's post-deploy handling relies on
+// this to detect a row that vanished concurrently.
+func TestSetProviderData_ReturnsNilForMissingTray(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	updated, err := repo.SetProviderData(context.Background(), "no-such-tray", map[string]string{
+		"zone": "us-east-1",
+	})
+	if err != nil {
+		t.Errorf("Expected no error for missing tray, got: %v", err)
+	}
+	if updated != nil {
+		t.Errorf("Expected nil tray for missing id, got %v", updated)
+	}
+}
+
+// TestSetProviderData_EmptyDataIsRead verifies that calling with no keys is
+// a read of the current state, not a no-op or error.
+func TestSetProviderData_EmptyDataIsRead(t *testing.T) {
+	client, collection := setupTestCollection(t)
+	defer client.Disconnect(context.Background())
+
+	repo := NewMongodbTrayRepository()
+	repo.Connect(collection)
+
+	tray := createTestTray("test-tray-1", "test-type", trays.TrayStatusRegistered, 0)
+	insertTestTrays(t, collection, []*TestTray{tray})
+
+	updated, err := repo.SetProviderData(context.Background(), "test-tray-1", nil)
+	if err != nil {
+		t.Fatalf("SetProviderData with nil data failed: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("Expected current row to be returned")
+	}
+	if updated.Status != trays.TrayStatusRegistered {
+		t.Errorf("Expected status=registered, got %v", updated.Status)
+	}
+}
+
 // TestNewMongodbTrayRepository tests the NewMongodbTrayRepository constructor
 func TestNewMongodbTrayRepository(t *testing.T) {
 	// Create a new repository

--- a/src/lib/trays/repositories/trayRepository.go
+++ b/src/lib/trays/repositories/trayRepository.go
@@ -12,6 +12,11 @@ type TrayRepository interface {
 	Save(ctx context.Context, tray *trays.Tray) error
 	Delete(ctx context.Context, trayId string) error
 	UpdateStatus(ctx context.Context, trayId string, status trays.TrayStatus, jobRunId int64, workflowRunId int64, ghRunnerId int64, repository string, jobName string, workflowName string) (*trays.Tray, error)
+	// SetProviderData writes the supplied keys into the row's providerData map
+	// (via $set on each providerData.<key>) without modifying status or other
+	// fields. Returns the row as it exists after the write, or (nil, nil) if
+	// the row is missing.
+	SetProviderData(ctx context.Context, trayId string, data map[string]string) (*trays.Tray, error)
 	CountActive(ctx context.Context, trayType string) (int, error)
 	// GetStale returns trays whose status is a key in thresholds and whose
 	// statusChanged is older than the corresponding duration. A status absent

--- a/src/server/handlers/agentHandler_test.go
+++ b/src/server/handlers/agentHandler_test.go
@@ -13,6 +13,7 @@ import (
 	"cattery/lib/trayManager"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,24 +21,35 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Mock provider factory ---
 
-type mockProvider struct{}
+type mockProvider struct {
+	cleanErr error
+}
 
-func (m *mockProvider) GetProviderName() string                              { return "mock" }
-func (m *mockProvider) StartDeploy(_ context.Context, _ *trays.Tray) error  { return nil }
-func (m *mockProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error   { return nil }
-func (m *mockProvider) CleanTray(_ context.Context, _ *trays.Tray) error    { return nil }
+func (m *mockProvider) GetProviderName() string                             { return "mock" }
+func (m *mockProvider) StartDeploy(_ context.Context, _ *trays.Tray) error { return nil }
+func (m *mockProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error  { return nil }
+func (m *mockProvider) CleanTray(_ context.Context, _ *trays.Tray) error   { return m.cleanErr }
 
-type mockProviderFactory struct{}
+type mockProviderFactory struct {
+	provider *mockProvider
+}
 
 func (m *mockProviderFactory) GetProvider(_ string) (providers.TrayProvider, error) {
-	return &mockProvider{}, nil
+	return m.providerOrDefault(), nil
 }
 func (m *mockProviderFactory) GetProviderForTray(_ *trays.Tray) (providers.TrayProvider, error) {
-	return &mockProvider{}, nil
+	return m.providerOrDefault(), nil
+}
+func (m *mockProviderFactory) providerOrDefault() *mockProvider {
+	if m.provider != nil {
+		return m.provider
+	}
+	return &mockProvider{}
 }
 
 // --- Mock restarter repository ---
@@ -84,6 +96,14 @@ func setupHandlersWithRestarter(repo *testutil.MockTrayRepository, restarterRepo
 	return &Handlers{
 		TrayManager:     trayManager.NewTrayManager(repo, &mockProviderFactory{}),
 		RestartManager:  restarter.NewWorkflowRestarter(restarterRepo),
+		ScaleSetManager: scaleSetPoller.NewManager(),
+	}
+}
+
+func setupHandlersWithProvider(repo *testutil.MockTrayRepository, prov *mockProvider) *Handlers {
+	return &Handlers{
+		TrayManager:     trayManager.NewTrayManager(repo, &mockProviderFactory{provider: prov}),
+		RestartManager:  restarter.NewWorkflowRestarter(&mockRestarterRepository{}),
 		ScaleSetManager: scaleSetPoller.NewManager(),
 	}
 }
@@ -207,6 +227,57 @@ func TestAgentUnregister_InvalidBody(t *testing.T) {
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAgentUnregister_Success_RowDeleted(t *testing.T) {
+	repo := testutil.NewMockTrayRepository()
+	repo.Trays["tray-1"] = &trays.Tray{
+		Id:           "tray-1",
+		Status:       trays.TrayStatusRunning,
+		ProviderData: map[string]string{},
+	}
+	h := setupHandlersWithProvider(repo, &mockProvider{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /agent/{id}/unregister", h.AgentUnregister)
+
+	body, _ := json.Marshal(messages.UnregisterRequest{Reason: messages.UnregisterReasonDone})
+	req := httptest.NewRequest("POST", "/agent/tray-1/unregister", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, repo.Trays, "row removed when cleanup succeeds")
+}
+
+func TestAgentUnregister_Returns200_EvenWhenCleanupFails(t *testing.T) {
+	// Load-bearing for the new lifecycle: when CleanTray fails, the agent
+	// (which is shutting down anyway) must still see a successful HTTP
+	// response. The row is left in deleting status for the stale handler
+	// to retry. Returning 500 here used to break agents that retried
+	// unregister on error.
+	repo := testutil.NewMockTrayRepository()
+	repo.Trays["tray-1"] = &trays.Tray{
+		Id:           "tray-1",
+		Status:       trays.TrayStatusRunning,
+		ProviderData: map[string]string{},
+	}
+	h := setupHandlersWithProvider(repo, &mockProvider{
+		cleanErr: errors.New("cloud API rate limit"),
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /agent/{id}/unregister", h.AgentUnregister)
+
+	body, _ := json.Marshal(messages.UnregisterRequest{Reason: messages.UnregisterReasonDone})
+	req := httptest.NewRequest("POST", "/agent/tray-1/unregister", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "cleanup failure must not propagate to the agent")
+	require.Contains(t, repo.Trays, "tray-1", "row must remain so stale handler can retry")
+	assert.Equal(t, trays.TrayStatusDeleting, repo.Trays["tray-1"].Status,
+		"row must be marked deleting even though cleanup failed")
 }
 
 // --- AgentInterrupt tests ---

--- a/src/server/handlers/agentHandler_test.go
+++ b/src/server/handlers/agentHandler_test.go
@@ -26,9 +26,10 @@ import (
 
 type mockProvider struct{}
 
-func (m *mockProvider) GetProviderName() string       { return "mock" }
-func (m *mockProvider) RunTray(_ *trays.Tray) error   { return nil }
-func (m *mockProvider) CleanTray(_ *trays.Tray) error { return nil }
+func (m *mockProvider) GetProviderName() string                              { return "mock" }
+func (m *mockProvider) StartDeploy(_ context.Context, _ *trays.Tray) error  { return nil }
+func (m *mockProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error   { return nil }
+func (m *mockProvider) CleanTray(_ context.Context, _ *trays.Tray) error    { return nil }
 
 type mockProviderFactory struct{}
 

--- a/src/server/handlers/integration_test.go
+++ b/src/server/handlers/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -77,6 +78,10 @@ type testHarness struct {
 }
 
 func setupIntegrationTest(t *testing.T) *testHarness {
+	return setupIntegrationTestWithFactory(t, &integrationMockProviderFactory{})
+}
+
+func setupIntegrationTestWithFactory(t *testing.T, factory providers.TrayProviderFactory) *testHarness {
 	t.Helper()
 
 	// Set up config
@@ -121,7 +126,7 @@ func setupIntegrationTest(t *testing.T) *testHarness {
 	restartRepo.Connect(db.Collection("restarters"))
 
 	// Set up managers
-	tm := trayManager.NewTrayManager(trayRepo, &integrationMockProviderFactory{})
+	tm := trayManager.NewTrayManager(trayRepo, factory)
 	rm := restarter.NewWorkflowRestarter(restartRepo)
 
 	// Set up scale set manager with mock JIT client
@@ -498,4 +503,161 @@ func TestIntegration_DoubleUnregister(t *testing.T) {
 	w = httptest.NewRecorder()
 	th.mux.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- CreateTray lifecycle tests ---
+
+// observingProvider populates ProviderData during StartDeploy and reports
+// what it saw to the test. Used to verify the row is queryable from Mongo
+// at the moment StartDeploy runs (the original race fix) and that the data
+// it populates is persisted via SetProviderData afterward.
+type observingProvider struct {
+	repo            *repositories.MongodbTrayRepository
+	observedTrayId  string
+	rowVisibleInDB  bool
+	providerDataSet map[string]string
+}
+
+func (p *observingProvider) GetProviderName() string { return "mock" }
+func (p *observingProvider) StartDeploy(ctx context.Context, tray *trays.Tray) error {
+	p.observedTrayId = tray.Id
+	got, err := p.repo.GetById(ctx, tray.Id)
+	if err == nil && got != nil {
+		p.rowVisibleInDB = true
+	}
+	tray.ProviderData["zone"] = "us-east-1"
+	tray.ProviderData["instanceId"] = "i-test-12345"
+	p.providerDataSet = map[string]string{
+		"zone":       tray.ProviderData["zone"],
+		"instanceId": tray.ProviderData["instanceId"],
+	}
+	return nil
+}
+func (p *observingProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error { return nil }
+func (p *observingProvider) CleanTray(_ context.Context, _ *trays.Tray) error  { return nil }
+
+type observingProviderFactory struct {
+	provider *observingProvider
+}
+
+func (f *observingProviderFactory) GetProvider(_ string) (providers.TrayProvider, error) {
+	return f.provider, nil
+}
+func (f *observingProviderFactory) GetProviderForTray(_ *trays.Tray) (providers.TrayProvider, error) {
+	return f.provider, nil
+}
+
+func TestIntegration_CreateTray_RowSavedBeforeStartDeploy(t *testing.T) {
+	// The original bug: agent boots and registers before CreateTray finishes.
+	// Verify that with save-before-deploy, the row is queryable from Mongo by
+	// the time StartDeploy runs — and that ProviderData populated inside
+	// StartDeploy survives the round-trip via SetProviderData.
+	prov := &observingProvider{}
+	factory := &observingProviderFactory{provider: prov}
+	th := setupIntegrationTestWithFactory(t, factory)
+	prov.repo = th.trayRepo
+
+	err := th.tm.CreateTray(context.Background(), config.Get().TrayTypes[0])
+	require.NoError(t, err)
+
+	require.NotEmpty(t, prov.observedTrayId, "provider must have run")
+	assert.True(t, prov.rowVisibleInDB,
+		"row must be present in Mongo when StartDeploy runs (original race fix)")
+
+	// ProviderData populated inside StartDeploy must round-trip via Mongo.
+	final, err := th.trayRepo.GetById(context.Background(), prov.observedTrayId)
+	require.NoError(t, err)
+	require.NotNil(t, final, "row must still exist after CreateTray completes")
+	assert.Equal(t, trays.TrayStatusCreating, final.Status,
+		"CreateTray itself doesn't change status — agent register does")
+	assert.Equal(t, "us-east-1", final.ProviderData["zone"])
+	assert.Equal(t, "i-test-12345", final.ProviderData["instanceId"])
+}
+
+// gatedProvider blocks StartDeploy on a release channel so the test can
+// orchestrate concurrent operations during deploy.
+type gatedProvider struct {
+	startEntered chan struct{}
+	startRelease chan struct{}
+
+	mu      sync.Mutex
+	cleaned []string
+}
+
+func (p *gatedProvider) GetProviderName() string { return "mock" }
+func (p *gatedProvider) StartDeploy(_ context.Context, tray *trays.Tray) error {
+	close(p.startEntered)
+	<-p.startRelease
+	tray.ProviderData["zone"] = "us-east-1"
+	return nil
+}
+func (p *gatedProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error { return nil }
+func (p *gatedProvider) CleanTray(_ context.Context, tray *trays.Tray) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cleaned = append(p.cleaned, tray.Id)
+	return nil
+}
+
+type gatedProviderFactory struct {
+	provider *gatedProvider
+}
+
+func (f *gatedProviderFactory) GetProvider(_ string) (providers.TrayProvider, error) {
+	return f.provider, nil
+}
+func (f *gatedProviderFactory) GetProviderForTray(_ *trays.Tray) (providers.TrayProvider, error) {
+	return f.provider, nil
+}
+
+func TestIntegration_CreateTray_ConcurrentUnregister(t *testing.T) {
+	// Concurrency at integration level: while StartDeploy is in flight, an
+	// unregister HTTP request fires. The unregister handler marks the row
+	// as deleting, runs CleanTray, and removes the row. CreateTray then
+	// proceeds, finds the row gone on its post-StartDeploy SetProviderData,
+	// and exits cleanly. End state: no row, no leaked provider resources.
+	prov := &gatedProvider{
+		startEntered: make(chan struct{}),
+		startRelease: make(chan struct{}),
+	}
+	th := setupIntegrationTestWithFactory(t, &gatedProviderFactory{provider: prov})
+
+	createDone := make(chan error, 1)
+	go func() {
+		createDone <- th.tm.CreateTray(context.Background(), config.Get().TrayTypes[0])
+	}()
+
+	// Wait for StartDeploy to be entered — at this point the row is in Mongo.
+	<-prov.startEntered
+
+	// Find the trayId via the repo (it was Saved before StartDeploy).
+	list, err := th.trayRepo.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	trayId := list[0].Id
+
+	// Fire the unregister HTTP request from the agent.
+	unregBody, _ := json.Marshal(messages.UnregisterRequest{
+		Reason: messages.UnregisterReasonDone,
+	})
+	req := httptest.NewRequest("POST", "/agent/unregister/"+trayId, bytes.NewReader(unregBody))
+	w := httptest.NewRecorder()
+	th.mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "unregister must succeed even mid-deploy")
+
+	// Release StartDeploy. CreateTray completes its post-deploy bookkeeping.
+	close(prov.startRelease)
+	require.NoError(t, <-createDone, "CreateTray must not error after concurrent unregister")
+
+	// Final state: row gone (cleaned up by the unregister path).
+	final, err := th.trayRepo.GetById(context.Background(), trayId)
+	require.NoError(t, err)
+	assert.Nil(t, final, "row must be cleaned up after unregister")
+
+	// CleanTray ran exactly once — the unregister path. CreateTray's
+	// post-WaitDeploy SetProviderData saw the row was missing and skipped
+	// its own cleanup attempt. No double-clean.
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Equal(t, []string{trayId}, prov.cleaned, "exactly one CleanTray call expected")
 }

--- a/src/server/handlers/integration_test.go
+++ b/src/server/handlers/integration_test.go
@@ -52,9 +52,10 @@ var _ scaleSetClient.JitConfigGenerator = (*mockJitConfigGenerator)(nil)
 // mockProviderFactory implements providers.TrayProviderFactory
 type integrationMockProvider struct{}
 
-func (m *integrationMockProvider) GetProviderName() string       { return "mock" }
-func (m *integrationMockProvider) RunTray(_ *trays.Tray) error   { return nil }
-func (m *integrationMockProvider) CleanTray(_ *trays.Tray) error { return nil }
+func (m *integrationMockProvider) GetProviderName() string                             { return "mock" }
+func (m *integrationMockProvider) StartDeploy(_ context.Context, _ *trays.Tray) error { return nil }
+func (m *integrationMockProvider) WaitDeploy(_ context.Context, _ *trays.Tray) error  { return nil }
+func (m *integrationMockProvider) CleanTray(_ context.Context, _ *trays.Tray) error   { return nil }
 
 type integrationMockProviderFactory struct{}
 


### PR DESCRIPTION
`TrayManager` only saves the tray after receiving a response from `TrayProvider`. However, the tray may have already booted, attempted to register, and received a 404 error
Fix: save trays to store before calling `RunTray()`