### PR TITLE
Proper `healthcheck` endpoints

### DIFF
--- a/charts/cattery/README.md
+++ b/charts/cattery/README.md
@@ -128,8 +128,9 @@ the path `config.github[*].privateKeyPath` expects. Two modes per entry:
 
 `config.server.statusListenAddress` can be set to serve `/status` and
 `/metrics` on a separate port. When set, the chart opens a second Service
-port and the `ServiceMonitor` scrapes that port. Probes always target
-whichever port `/status` is on.
+port and the `ServiceMonitor` scrapes that port. Probes hit `/healthcheck`,
+which is registered on both ports; they target the status port when set,
+otherwise the main http port.
 
 ### ServiceMonitor
 

--- a/charts/cattery/templates/deployment.yaml
+++ b/charts/cattery/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /status
+              path: /healthcheck
               port: {{ include "cattery.probePort" . }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -81,7 +81,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /status
+              path: /healthcheck
               port: {{ include "cattery.probePort" . }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/cattery/values.yaml
+++ b/charts/cattery/values.yaml
@@ -153,8 +153,9 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# Probes hit /status. They target the status port when
+# Probes hit /healthcheck. They target the status port when
 # config.server.statusListenAddress is set, otherwise the main http port.
+# /healthcheck is registered on both ports.
 livenessProbe:
   enabled: true
   initialDelaySeconds: 15

--- a/src/server/handlers/rootHandler.go
+++ b/src/server/handlers/rootHandler.go
@@ -13,6 +13,18 @@ type Handlers struct {
 	ScaleSetManager *scaleSetPoller.Manager
 }
 
-func (h *Handlers) Index(responseWriter http.ResponseWriter, r *http.Request) {
-	http.Redirect(responseWriter, r, "/status", http.StatusFound)
+func (h *Handlers) Index(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("cattery\n"))
+}
+
+func (h *Handlers) StatusIndex(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/status", http.StatusFound)
+}
+
+func (h *Handlers) Healthcheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -153,6 +153,8 @@ func Start() {
 
 func agentMux(h *handlers.Handlers) *http.ServeMux {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/{$}", h.Index)
+	mux.HandleFunc("GET /healthcheck", h.Healthcheck)
 	mux.HandleFunc("GET /agent/register/{id}", h.AgentRegister)
 	mux.HandleFunc("POST /agent/unregister/{id}", h.AgentUnregister)
 	mux.HandleFunc("GET /agent/download", handlers.AgentDownloadBinary)
@@ -162,7 +164,6 @@ func agentMux(h *handlers.Handlers) *http.ServeMux {
 }
 
 func registerStatusRoutes(mux *http.ServeMux, h *handlers.Handlers) {
-	mux.HandleFunc("/{$}", h.Index)
 	mux.HandleFunc("/status", h.Status)
 	mux.HandleFunc("GET /status/data", h.StatusData)
 	mux.Handle("/metrics", promhttp.Handler())
@@ -195,6 +196,8 @@ func startServers(logger *log.Logger, cancel context.CancelFunc, h *handlers.Han
 	}
 
 	sMux := http.NewServeMux()
+	sMux.HandleFunc("/{$}", h.StatusIndex)
+	sMux.HandleFunc("GET /healthcheck", h.Healthcheck)
 	registerStatusRoutes(sMux, h)
 	return []*http.Server{
 		listenAndServe(logger, cancel, mainAddr, aMux),


### PR DESCRIPTION
`/healthcheck` edpoint
  - if single port: no '/' -> '/status' redirect, serve '/healthcheck'
  - if separate ports: status redirect '/' -> '/status', both serve '/healthcheck'